### PR TITLE
HUT-321 - feat: Update API URL

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -216,7 +216,7 @@ const promiseRequest = async (
   });
 
 function _apiUrl(path: string): string {
-  return `https://app.hutte.io/cli_api${path}`;
+  return `https://api.hutte.io/cli_api${path}`;
 }
 
 export { getScratchOrgs, takeOrgFromPool, login, IScratchOrg };


### PR DESCRIPTION
- Update API URL to the specific endpoint of the Public API instead of the Web-endpoint.
- Manually tested for each Hutte command, successful result (expected as the all calls to the web-endpoint "app.hutte.io"can be reached through "api.hutte.io" as well)