### PR TITLE
HUT-1132 basic unit tests

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -22,8 +22,8 @@ jobs:
         run: |
           yarn install
           yarn global add sfdx-cli
-      # - name: Run tests
-      #   run: yarn run test
+      - name: Run Unit Tests
+        run: yarn test
       - name: Release package
         run: npx semantic-release
         env:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,7 +33,8 @@
           "test/**/*.test.ts"
       ],
       "cwd": "${workspaceRoot}",
-      "preLaunchTask": "Compile"
+      "preLaunchTask": "Compile",
+      "internalConsoleOptions": "openOnSessionStart"
     },
     {
       "name": "Run Current Unit Test",
@@ -56,7 +57,8 @@
           "${file}"
       ],
       "cwd": "${workspaceRoot}",
-      "preLaunchTask": "Compile"
+      "preLaunchTask": "Compile",
+      "internalConsoleOptions": "openOnSessionStart"
     }
   ]
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -59,7 +59,7 @@ interface IScratchOrg {
   pool: boolean;
 }
 
-interface IScratchOrgResponse {
+export interface IScratchOrgResponse {
   id: string;
   branch_name: string;
   commit_sha: string;
@@ -194,7 +194,7 @@ export const terminateOrg = async (
   });
 };
 
-const promiseRequest = async (
+export const promiseRequest = async (
   options: request.UriOptions & request.CoreOptions,
 ): Promise<{ response: request.Response; body: any }> =>
   new Promise<{ response: request.Response; body: any }>((resolve, reject) => {

--- a/src/commands/hutte/auth/login.ts
+++ b/src/commands/hutte/auth/login.ts
@@ -27,7 +27,7 @@ export default class Login extends SfdxCommand {
     }),
   };
 
-  protected static requiresProject = false;
+  static requiresProject = false;
 
   public async run(): Promise<void> {
     const email =

--- a/src/commands/hutte/org/authorize.ts
+++ b/src/commands/hutte/org/authorize.ts
@@ -17,7 +17,7 @@ import {
 export default class Authorize extends SfdxCommand {
   public static description = 'authorize a scratch org from hutte.io';
 
-  protected static requiresProject = true;
+  static requiresProject = true;
 
   protected static flagsConfig = {
     'no-git': flags.boolean({

--- a/src/commands/hutte/org/terminate.ts
+++ b/src/commands/hutte/org/terminate.ts
@@ -11,7 +11,7 @@ export default class Terminate extends SfdxCommand {
   public static description =
     'terminates the default org on Hutte.io and logs out locally';
 
-  protected static requiresProject = true;
+  static requiresProject = true;
 
   protected static flagsConfig = {
     'api-token': flags.string({
@@ -31,19 +31,11 @@ export default class Terminate extends SfdxCommand {
     );
 
     if (terminateResponse.response.statusCode === 404) {
-      console.log(
-        'Could not find the scratch org on hutte. Are you sure you are in the correct project?',
-      );
-      this.exit(1);
+      return Promise.reject('Could not find the scratch org on hutte. Are you sure you are in the correct project?');
     }
 
     if (Math.floor(terminateResponse.response.statusCode / 100) !== 2) {
-      console.log(
-        'Request to hutte failed',
-        terminateResponse.response.statusCode,
-        terminateResponse.body,
-      );
-      this.exit(1);
+      return Promise.reject('Request to hutte failed ' + terminateResponse.response.statusCode + ' ' + terminateResponse.body);
     }
 
     return logoutFromDefault();

--- a/src/commands/hutte/pool/take.ts
+++ b/src/commands/hutte/pool/take.ts
@@ -11,7 +11,7 @@ import {
 export default class Take extends SfdxCommand {
   public static description = 'take a scratch org from the pool';
 
-  protected static requiresProject = true;
+  static requiresProject = true;
 
   protected static flagsConfig = {
     'api-token': flags.string({
@@ -62,17 +62,16 @@ export default class Take extends SfdxCommand {
 
         if (body && body.error) {
           if (body.error === 'no_pool') {
-            console.log(
+            console.error(
               "This project doesn't have a pool defined. Setup a pool with at least one organization and try again.",
             );
           } else if (body.error === 'no_active_org') {
             if (this.flags.wait) {
               if (this.flags.timeout && iteration * 10 > this.flags.timeout) {
-                console.log('Timeout reached, finishing...');
-                this.exit(1);
+                return Promise.reject('Timeout reached, finishing...');
               }
 
-              console.log(
+              console.error(
                 'There is no active pool at the moment. Trying again in 10 seconds.',
               );
               return new Promise(() =>
@@ -80,16 +79,15 @@ export default class Take extends SfdxCommand {
               );
             }
 
-            console.log(
+            console.error(
               'There is no active pool at the moment, try again later.',
             );
           }
         } else {
-          console.log('Uknown request error.', e);
+          console.error('Uknown request error.', e);
         }
 
-        console.log('Unknown error: ', e);
-        this.exit(1);
+        return Promise.reject('Unknown error: ' + JSON.stringify(e));
       });
   }
 

--- a/test/commands/auth/login.test.ts
+++ b/test/commands/auth/login.test.ts
@@ -10,14 +10,14 @@ describe('hutte:auth:login', async () => {
     initTest()
         .stub(api, 'login', () => Promise.resolve())
         .command(['hutte:auth:login', '--email', 'test@email.com', '--password', 'mockPassword'])
-        .it('happy path, login successfully', async ctx => {
+        .it('login happy path', async ctx => {
             expect(ctx.stdout).to.be.eql('');
         });
 
     initTest()
         .stub(api, 'login', () => Promise.reject('Invalid credentials'))
         .command(['hutte:auth:login', '--email', 'test@email.com', '--password', 'mockPassword'])
-        .it('fails with incorrect credentials', async ctx => {
+        .it('login fails when credentials are incorrect', async ctx => {
             expect(ctx.stdout).to.contain('Invalid credentials');
         });
     

--- a/test/commands/auth/login.test.ts
+++ b/test/commands/auth/login.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@salesforce/command/lib/test';
+import Login from '../../../src/commands/hutte/auth/login';
+import * as api from '../../../src/api';
+import * as keychain from '../../../src/keychain';
+import * as config from '../../../src/config';
+
+describe('hutte:auth:login', async () => {
+    Login.requiresProject = false;
+
+    initTest()
+        .stub(api, 'login', () => Promise.resolve())
+        .command(['hutte:auth:login', '--email', 'test@email.com', '--password', 'mockPassword'])
+        .it('happy path, login successfully', async ctx => {
+            expect(ctx.stdout).to.be.eql('');
+        });
+
+    initTest()
+        .stub(api, 'login', () => Promise.reject('Invalid credentials'))
+        .command(['hutte:auth:login', '--email', 'test@email.com', '--password', 'mockPassword'])
+        .it('fails with incorrect credentials', async ctx => {
+            expect(ctx.stdout).to.contain('Invalid credentials');
+        });
+    
+});
+
+function initTest() {
+    return test
+        .withConnectionRequest(() => Promise.resolve({}))
+        .stdout()
+        .stderr()
+        .stub(keychain, 'storeUserApiToken', () => Promise.resolve())
+        .stub(config, 'storeUserInfo', () => Promise.resolve())
+  }

--- a/test/commands/org/authorize.test.ts
+++ b/test/commands/org/authorize.test.ts
@@ -11,7 +11,7 @@ describe('hutte:org:authorize', async () => {
 
     initTest()
         .command(['hutte:org:authorize'])
-        .it('happy path, login successfully', async ctx => {
+        .it('authorize happy path', async ctx => {
             expect(ctx.stdout).to.be.eql('');
             expect(ctx.stderr).to.be.eql('');
         });
@@ -30,7 +30,7 @@ describe('hutte:org:authorize', async () => {
             }
         })
         .command(['hutte:org:authorize'])
-        .it('fails on sfdx error', async ctx => {
+        .it('authorize fails on sfdx error', async ctx => {
             expect(ctx.stdout).to.be.eql('');
             expect(ctx.stderr).to.contains('ERROR running hutte:org:authorize:  The sfdx login failed.');
         });
@@ -48,7 +48,7 @@ describe('hutte:org:authorize', async () => {
             }
         })
         .command(['hutte:org:authorize'])
-        .it('fails on unstaged changes', async ctx => {
+        .it('authorize fails on unstaged changes', async ctx => {
             expect(ctx.stdout).to.be.eql('');
             expect(ctx.stderr).to.contains('ERROR running hutte:org:authorize:  You have unstaged changes. Please commit or stash them before proceeding.');
         });
@@ -121,6 +121,7 @@ function initTest() {
             email: 'mockUser@hutte.io',
             userId: '123467890-1234567890'
         }))
+        // @Note: This stubs the API Call to Hutte API to get the Hutte authenticated orgs information
         .stub(api, 'promiseRequest', () => Promise.resolve({
             body: {
                 data: [mockReceivedOrg]

--- a/test/commands/org/authorize.test.ts
+++ b/test/commands/org/authorize.test.ts
@@ -1,0 +1,132 @@
+import { expect, test } from '@salesforce/command/lib/test';
+import Authorize from '../../../src/commands/hutte/org/authorize';
+import * as api from '../../../src/api';
+import * as common from '../../../src/common';
+import * as config from '../../../src/config';
+import * as keychain from '../../../src/keychain';
+import cross_spawn from 'cross-spawn';
+
+describe('hutte:org:authorize', async () => {
+    Authorize.requiresProject = false;
+
+    initTest()
+        .command(['hutte:org:authorize'])
+        .it('happy path, login successfully', async ctx => {
+            expect(ctx.stdout).to.be.eql('');
+            expect(ctx.stderr).to.be.eql('');
+        });
+
+    initTest()
+        .stub(cross_spawn, 'sync', (command: string, args: string[]) => {
+            if (command == 'git') {
+                return { 
+                    status: 0,
+                    stdout: 'https://github.com/mock-org/mock-repo.git\n'
+                }
+            } else if (command  == 'sfdx') {
+                return {
+                    status: 1
+                }
+            }
+        })
+        .command(['hutte:org:authorize'])
+        .it('fails on sfdx error', async ctx => {
+            expect(ctx.stdout).to.be.eql('');
+            expect(ctx.stderr).to.contains('ERROR running hutte:org:authorize:  The sfdx login failed.');
+        });
+
+    initTest()
+        .stub(cross_spawn, 'sync', (command: string, args: string[]) => {
+            if (command == 'git') {
+                return { 
+                    status: 1
+                }
+            } else if (command  == 'sfdx') {
+                return {
+                    status: 0
+                }
+            }
+        })
+        .command(['hutte:org:authorize'])
+        .it('fails on unstaged changes', async ctx => {
+            expect(ctx.stdout).to.be.eql('');
+            expect(ctx.stderr).to.contains('ERROR running hutte:org:authorize:  You have unstaged changes. Please commit or stash them before proceeding.');
+        });
+});
+
+function initTest() {
+    const mockReceivedOrg: api.IScratchOrgResponse = {
+        "id": "mockId",
+        "branch_name": "mockBranch1",
+        "commit_sha": "1234567890",
+        "devhub_id": "00D7Q000005YnXXXXX",
+        "devhub_sfdx_auth_url": "force://mockDevHubUrl",
+        "name": "Test Playground 1",
+        "project_name": "Test Playground 1",
+        "sfdx_auth_url": "force://mockUrl1",
+        "revision_number": "0",
+        "slug": "mock",
+        "state": "active",
+        "salesforce_id": "mockId",
+        "remaining_days": '1',
+        "project_id": "mockProjectId",
+        "initial_branch_name": "master",
+        "gid": "mockGlobalId",
+        "domain": "CS162",
+        "created_at": "2023-05-31T10:11:57.135Z",
+        "created_by": "Test User",
+        "pool": false
+    };
+
+    const mockParsedOrg: api.IScratchOrg = {
+        "id": "mockId",
+        "branchName": "mockBranch1",
+        "commitSha": '1234567890',
+        "devhubId": "00D7Q000005YnXXXXX",
+        "devhubSfdxAuthUrl": "force://mockDevHubUrl",
+        "name": "Test Playground 1",
+        "projectName": "Test Playground 1",
+        "sfdxAuthUrl": "force://mockUrl1",
+        "revisionNumber": "0",
+        "slug": "mock",
+        "state": "active",
+        "salesforceId": "mockId",
+        "remainingDays": 1,
+        "projectId": "mockProjectId",
+        "initialBranchName": "master",
+        "globalId": "mockGlobalId",
+        "domain": "CS162",
+        "createdAt": "2023-05-31T10:11:57.135Z",
+        "createdBy": "Test User",
+        "pool": false
+    }
+
+    return test
+        .withConnectionRequest(() => Promise.resolve({}))
+        .stdout()
+        .stderr()
+        .stub(cross_spawn, 'sync', (command: string, args: string[]) => {
+            if (command == 'git') {
+                return { 
+                    status: 0,
+                    stdout: 'https://github.com/mock-org/mock-repo.git\n'
+                }
+            } else if (command  == 'sfdx') {
+                return {
+                    status: 0
+                }
+            }
+        })
+        .stub(config, 'getCurrentUserInfo', () => Promise.resolve({
+            email: 'mockUser@hutte.io',
+            userId: '123467890-1234567890'
+        }))
+        .stub(api, 'promiseRequest', () => Promise.resolve({
+            body: {
+                data: [mockReceivedOrg]
+            }
+        }))
+        .stub(common, 'flagAsScratchOrg', () => Promise.resolve(mockParsedOrg))
+        .stub(keychain, 'getUserApiToken', () => Promise.resolve('mockPassword'))
+        .stub(common, 'devHubSfdxLogin', () => Promise.resolve(mockParsedOrg))
+  }

--- a/test/commands/org/terminate.test.ts
+++ b/test/commands/org/terminate.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from '@salesforce/command/lib/test';
+import Terminate from '../../../src/commands/hutte/org/terminate';
+import * as api from '../../../src/api';
+import * as common from '../../../src/common';
+import * as config from '../../../src/config';
+import cross_spawn from 'cross-spawn';
+
+describe('hutte:org:terminate', async () => {
+    Terminate.requiresProject = false;
+
+    initTest()
+        .command(['hutte:org:terminate'])
+        .it('terminate scratch org happy path', async ctx => {
+            expect(ctx.stdout).to.be.eql('');
+            expect(ctx.stderr).to.be.eql('');
+        });
+
+    initTest()
+        // @Note: This stubs the API Call to Hutte API to terminate the org
+        .stub(api, 'promiseRequest', () => Promise.resolve({
+            response: {
+                statusCode: 404
+            }
+        }))
+        .command(['hutte:org:terminate'])
+        .it('fails when the scratch org cannot be found in Hutte', async ctx => {
+            expect(ctx.stdout).to.be.eql('');
+            expect(ctx.stderr).to.contains('ERROR running hutte:org:terminate:  Could not find the scratch org on hutte. Are you sure you are in the correct project?');
+        });
+
+    initTest()
+        // @Note: This stubs the API Call to Hutte API to terminate the org
+        .stub(api, 'promiseRequest', () => Promise.resolve({
+            response: {
+                statusCode: 500
+            }
+        }))
+        .command(['hutte:org:terminate'])
+        .it('fails when Hutte API returns an error response', async ctx => {
+            expect(ctx.stdout).to.be.eql('');
+            expect(ctx.stderr).to.contains('ERROR running hutte:org:terminate:  Request to hutte failed 500 undefined');
+        });
+
+});
+
+function initTest() {
+    return test
+        .withConnectionRequest(() => Promise.resolve({}))
+        .stdout()
+        .stderr()
+        .stub(cross_spawn, 'sync', (command: string, args: string[]) => {
+            if (command == 'git') {
+                return { 
+                    status: 0,
+                    stdout: 'https://github.com/mock-org/mock-repo.git\n'
+                }
+            } else if (command  == 'sfdx') {
+                return {
+                    status: 0
+                }
+            }
+        })
+        .stub(common, 'logoutFromDefault', () => Promise.resolve())
+        .stub(common, 'getDefaultOrgInfo', () => Promise.resolve({
+            id: 'mockOrgId'
+        }))
+        .stub(config, 'getCurrentUserInfo', () => Promise.resolve({
+            email: 'mockUser@hutte.io',
+            userId: '123467890-1234567890'
+        }))
+        // @Note: This stubs the API Call to Hutte API to terminate the org
+        .stub(api, 'promiseRequest', () => Promise.resolve({
+            response: {
+                statusCode: 200
+            }
+        }))
+  }

--- a/test/commands/org/terminate.test.ts
+++ b/test/commands/org/terminate.test.ts
@@ -51,6 +51,7 @@ function initTest() {
         .stderr()
         .stub(keychain, 'storeUserApiToken', () => Promise.resolve())
         .stub(config, 'storeUserInfo', () => Promise.resolve())
+        .stub(keychain, 'getUserApiToken', () => Promise.resolve('mockPassword'))
         .stub(cross_spawn, 'sync', (command: string, args: string[]) => {
             if (command == 'git') {
                 return { 

--- a/test/commands/org/terminate.test.ts
+++ b/test/commands/org/terminate.test.ts
@@ -3,6 +3,7 @@ import Terminate from '../../../src/commands/hutte/org/terminate';
 import * as api from '../../../src/api';
 import * as common from '../../../src/common';
 import * as config from '../../../src/config';
+import * as keychain from '../../../src/keychain';
 import cross_spawn from 'cross-spawn';
 
 describe('hutte:org:terminate', async () => {
@@ -48,6 +49,8 @@ function initTest() {
         .withConnectionRequest(() => Promise.resolve({}))
         .stdout()
         .stderr()
+        .stub(keychain, 'storeUserApiToken', () => Promise.resolve())
+        .stub(config, 'storeUserInfo', () => Promise.resolve())
         .stub(cross_spawn, 'sync', (command: string, args: string[]) => {
             if (command == 'git') {
                 return { 

--- a/test/commands/pool/take.test.ts
+++ b/test/commands/pool/take.test.ts
@@ -1,0 +1,127 @@
+import { expect, test } from '@salesforce/command/lib/test';
+import Take from '../../../src/commands/hutte/pool/take';
+import * as api from '../../../src/api';
+import * as common from '../../../src/common';
+import * as keychain from '../../../src/keychain';
+import cross_spawn from 'cross-spawn';
+
+describe('hutte:pool:take', async () => {
+    Take.requiresProject = false;
+
+    initTest()
+        .command(['hutte:pool:take', '--name', 'mockOrg', '--timeout', '60', '--wait'])
+        .it('take from pool happy path', async ctx => {
+            expect(ctx.stdout).to.be.eql('');
+            expect(ctx.stderr).to.be.eql('');
+        });
+
+    initTest()
+        // @Note: This stubs the API Call to Hutte API to take an org from the pool
+        .stub(api, 'promiseRequest', () => Promise.resolve({
+            response: {
+                statusCode: 500
+            },
+            body: {
+                error: 'no_pool'
+            }
+        }))
+        .command(['hutte:pool:take', '--name', 'mockOrg'])
+        .it('fails when there is not a pool in the project', async ctx => {
+            expect(ctx.stdout).to.be.eql('');
+            expect(ctx.stderr).to.contains('This project doesn\'t have a pool defined. Setup a pool with at least one organization and try again');
+        });
+
+    initTest()
+        // @Note: This stubs the API Call to Hutte API to take an org from the pool
+        .stub(api, 'promiseRequest', () => Promise.resolve({
+            response: {
+                statusCode: 500
+            },
+            body: {
+                error: 'no_active_org'
+            }
+        }))
+        .command(['hutte:pool:take', '--name', 'mockOrg'])
+        .it('fails when there is not an active org at the pool', async ctx => {
+            expect(ctx.stdout).to.be.eql('');
+            expect(ctx.stderr).to.contains('There is no active pool at the moment, try again later.');
+        });
+
+});
+
+function initTest() {
+    const mockReceivedOrg: api.IScratchOrgResponse = {
+        "id": "mockId",
+        "branch_name": "mockBranch1",
+        "commit_sha": "1234567890",
+        "devhub_id": "00D7Q000005YnXXXXX",
+        "devhub_sfdx_auth_url": "force://mockDevHubUrl",
+        "name": "Test Playground 1",
+        "project_name": "Test Playground 1",
+        "sfdx_auth_url": "force://mockUrl1",
+        "revision_number": "0",
+        "slug": "mock",
+        "state": "active",
+        "salesforce_id": "mockId",
+        "remaining_days": '1',
+        "project_id": "mockProjectId",
+        "initial_branch_name": "master",
+        "gid": "mockGlobalId",
+        "domain": "CS162",
+        "created_at": "2023-05-31T10:11:57.135Z",
+        "created_by": "Test User",
+        "pool": false
+    };
+
+    const mockParsedOrg: api.IScratchOrg = {
+        "id": "mockId",
+        "branchName": "mockBranch1",
+        "commitSha": '1234567890',
+        "devhubId": "00D7Q000005YnXXXXX",
+        "devhubSfdxAuthUrl": "force://mockDevHubUrl",
+        "name": "Test Playground 1",
+        "projectName": "Test Playground 1",
+        "sfdxAuthUrl": "force://mockUrl1",
+        "revisionNumber": "0",
+        "slug": "mock",
+        "state": "active",
+        "salesforceId": "mockId",
+        "remainingDays": 1,
+        "projectId": "mockProjectId",
+        "initialBranchName": "master",
+        "globalId": "mockGlobalId",
+        "domain": "CS162",
+        "createdAt": "2023-05-31T10:11:57.135Z",
+        "createdBy": "Test User",
+        "pool": false
+    }
+
+    return test
+        .withConnectionRequest(() => Promise.resolve({}))
+        .stdout()
+        .stderr()
+        .stub(keychain, 'getUserApiToken', () => Promise.resolve('mockPassword'))
+        .stub(cross_spawn, 'sync', (command: string, args: string[]) => {
+            if (command == 'git') {
+                return { 
+                    status: 0,
+                    stdout: 'https://github.com/mock-org/mock-repo.git\n'
+                }
+            } else if (command  == 'sfdx') {
+                return {
+                    status: 0
+                }
+            }
+        })
+        // @Note: This stubs the API Call to Hutte API to take an org from the pool
+        .stub(api, 'promiseRequest', () => Promise.resolve({
+            response: {
+                statusCode: 200
+            },
+            body: {
+                data: mockReceivedOrg
+            }
+        }))
+        .stub(common, 'devHubSfdxLogin', () => Promise.resolve(mockParsedOrg))
+        .stub(common, 'flagAsScratchOrg', () => Promise.resolve(mockParsedOrg))
+  }

--- a/test/commands/pool/take.test.ts
+++ b/test/commands/pool/take.test.ts
@@ -3,6 +3,7 @@ import Take from '../../../src/commands/hutte/pool/take';
 import * as api from '../../../src/api';
 import * as common from '../../../src/common';
 import * as keychain from '../../../src/keychain';
+import * as config from '../../../src/config';
 import cross_spawn from 'cross-spawn';
 
 describe('hutte:pool:take', async () => {
@@ -100,6 +101,10 @@ function initTest() {
         .withConnectionRequest(() => Promise.resolve({}))
         .stdout()
         .stderr()
+        .stub(config, 'getCurrentUserInfo', () => Promise.resolve({
+            email: 'mockUser@hutte.io',
+            userId: '123467890-1234567890'
+        }))
         .stub(keychain, 'getUserApiToken', () => Promise.resolve('mockPassword'))
         .stub(cross_spawn, 'sync', (command: string, args: string[]) => {
             if (command == 'git') {


### PR DESCRIPTION
1. Added basic unit tests to:
- hutte:auth:login
- hutte:org:authorize
- hutte:org:terminate
- hutte:pool:take

2. Minor refactors in the code, not affecting the behaviour of it, some of those for the correct execution of tests

3. Added unit test execution in the Github CICD pipeline