### PR TITLE
fix: parse Bitbucket Server Git URLs [HUT-2055]

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -84,7 +84,9 @@ export function extractGithubRepoName(remoteUrl: string): string {
   if (url.slice(-4) === '.git') {
     url = url.slice(0, -4);
   }
-  return url;
+  // the last two parts of the url path
+  const repoName = url.split('/').slice(-2).join('/');
+  return repoName;
 }
 
 export async function retryWithTimeout<T>(

--- a/test/common.test.ts
+++ b/test/common.test.ts
@@ -1,6 +1,6 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
-import { retryWithTimeout } from '../src/common';
+import { describe, it } from 'mocha';
+import { extractGithubRepoName, retryWithTimeout } from '../src/common';
 
 describe('common', () => {
   describe('retryWithTimeout', () => {
@@ -70,6 +70,19 @@ describe('common', () => {
       }
       expect(err).to.match(/please retry again/);
       expect(i).to.equal(2);
+    });
+  });
+
+  describe('extractGithubRepoName', () => {
+    it('should parse a GitHub repo URL', () => {
+      expect(extractGithubRepoName('https://github.com/orgname/reponame.git')).to.deep.equal('orgname/reponame');
+      expect(extractGithubRepoName('git@github.com:orgname/reponame.git')).to.deep.equal('orgname/reponame');
+    });
+    it('should parse a Bitbucket Server repo URL', () => {
+      expect(extractGithubRepoName('https://git.example.org/scm/orgname/reponame.git')).to.deep.equal(
+        'orgname/reponame',
+      );
+      expect(extractGithubRepoName('ssh://git@git.example.org/orgname/reponame.git')).to.deep.equal('orgname/reponame');
     });
   });
 });


### PR DESCRIPTION
Bitbucket Server Git URLs are different to GitHub URLs and might include a leading 'scm' in the URL path.
Example: `https://git.example.org/scm/orgname/reponame.git`