### PR TITLE
fix: replace postinstall with prepare for husky setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "compile": "wireit",
     "format": "wireit",
     "lint": "wireit",
-    "postinstall": "yarn husky install",
+    "prepare": "husky install",
     "postpack": "sf-clean --ignore-signing-artifacts",
     "prepack": "sf-prepack",
     "test": "wireit",


### PR DESCRIPTION
## Summary

- Replace `postinstall` script with `prepare` in `package.json` to fix plugin installation failing with "Command husky not found"
- The `postinstall` lifecycle script runs for all consumers who install the package, but `husky` is only a devDependency — causing the install to fail
- The `prepare` script only runs during local development and publish, which is the [recommended husky setup](https://typicode.github.io/husky/get-started.html)