### PR TITLE
feat: support HTTP proxy via HTTPS_PROXY environment variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "chalk": "^5.6.0",
     "cross-spawn": "^7.0.6",
     "fuse.js": "^7.1.0",
+    "got": "^13.0.0",
+    "https-proxy-agent": "^7.0.0",
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,18 +1,23 @@
 import { Messages } from '@salesforce/core';
+import { RequestError, type OptionsOfJSONResponseBody, type Response } from 'got';
+import { getHttpClient } from './http-client.js';
 import { type ResolvedProject } from './types.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const sharedMessages = Messages.loadMessages('hutte', 'shared');
 
-function apiUrl(path: string): string {
-  return `https://api.hutte.io/cli_api${path}`;
-}
-
-async function apiFetch(url: string, options: RequestInit): Promise<Response> {
+async function apiRequest<T>(
+  method: 'get' | 'post',
+  path: string,
+  options?: OptionsOfJSONResponseBody
+): Promise<Response<T>> {
   try {
-    return await fetch(url, options);
+    return await getHttpClient()(path, { method, ...options });
   } catch (error) {
-    throw sharedMessages.createError('error.networkError', undefined, undefined, error as Error);
+    if (error instanceof RequestError) {
+      throw sharedMessages.createError('error.networkError', undefined, undefined, error);
+    }
+    throw error;
   }
 }
 
@@ -23,29 +28,36 @@ function authHeaders(apiToken: string): Record<string, string> {
   };
 }
 
+function projectParams(project: ResolvedProject): Record<string, string> {
+  /* eslint-disable camelcase */
+  const params: Record<string, string> = {};
+  if (project.repoName) params.repo_name = project.repoName;
+  if (project.projectId) params.project_id = project.projectId;
+  return params;
+  /* eslint-enable camelcase */
+}
+
 type ILoginResponse = {
   userId: string;
   apiToken: string;
 };
 
 async function login(email: string, password: string): Promise<ILoginResponse> {
-  const response = await apiFetch(apiUrl('/api_tokens'), {
-    method: 'POST',
+  const response = await apiRequest<{ data: { api_token: string; user_id: string } }>('post', 'api_tokens', {
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ email, password }),
+    json: { email, password },
   });
 
-  if (!response.ok) {
+  if (response.statusCode < 200 || response.statusCode >= 300) {
     throw sharedMessages.createError('error.authorization');
   }
 
-  const body = (await response.json()) as { data: { api_token: string; user_id: string } };
   return {
-    apiToken: body.data.api_token,
-    userId: body.data.user_id,
+    apiToken: response.body.data.api_token,
+    userId: response.body.data.user_id,
   };
 }
 
@@ -145,21 +157,19 @@ function mapScratchOrg(org: IScratchOrgResponse): IScratchOrg {
 }
 
 async function getProjects(apiToken: string): Promise<IProject[]> {
-  const response = await apiFetch(apiUrl('/projects'), {
-    method: 'GET',
+  const response = await apiRequest<{ data: IProjectResponse[] }>('get', 'projects', {
     headers: authHeaders(apiToken),
   });
 
-  if (response.status === 401) {
+  if (response.statusCode === 401) {
     throw sharedMessages.createError('error.authorization');
   }
 
-  if (!response.ok) {
+  if (response.statusCode < 200 || response.statusCode >= 300) {
     throw sharedMessages.createError('error.serverError');
   }
 
-  const body = (await response.json()) as { data: IProjectResponse[] };
-  return body.data.map((p) => ({
+  return response.body.data.map((p) => ({
     id: p.id,
     name: p.name,
     repository: p.repo_full_name,
@@ -167,93 +177,81 @@ async function getProjects(apiToken: string): Promise<IProject[]> {
   }));
 }
 
-function setProjectParams(url: URL, project: ResolvedProject): void {
-  if (project.repoName) url.searchParams.set('repo_name', project.repoName);
-  if (project.projectId) url.searchParams.set('project_id', project.projectId);
-}
-
 async function getScratchOrgs(
   apiToken: string,
   project: ResolvedProject,
   includeAll: boolean = false
 ): Promise<IScratchOrg[]> {
-  const url = new URL(apiUrl('/scratch_orgs'));
-  setProjectParams(url, project);
-  url.searchParams.set('all', includeAll.toString());
-
-  const response = await apiFetch(url.toString(), {
-    method: 'GET',
+  const response = await apiRequest<{ data: IScratchOrgResponse[] }>('get', 'scratch_orgs', {
     headers: authHeaders(apiToken),
+    searchParams: {
+      ...projectParams(project),
+      all: includeAll.toString(),
+    },
   });
 
-  if (response.status === 401) {
+  if (response.statusCode === 401) {
     throw sharedMessages.createError('error.authorization');
   }
 
-  if (!response.ok) {
+  if (response.statusCode < 200 || response.statusCode >= 300) {
     throw sharedMessages.createError('error.serverError');
   }
 
-  const body = (await response.json()) as { data: IScratchOrgResponse[] };
-  return body.data.map(mapScratchOrg);
+  return response.body.data.map(mapScratchOrg);
 }
 
 async function takeOrgFromPool(apiToken: string, project: ResolvedProject, orgName?: string): Promise<IScratchOrg> {
-  const url = new URL(apiUrl('/take_from_pool'));
-  setProjectParams(url, project);
-  if (orgName) url.searchParams.set('name', orgName);
+  const searchParams: Record<string, string> = { ...projectParams(project) };
+  if (orgName) searchParams.name = orgName;
 
-  const response = await apiFetch(url.toString(), {
-    method: 'POST',
+  const response = await apiRequest<{ data: IScratchOrgResponse; error?: string }>('post', 'take_from_pool', {
     headers: authHeaders(apiToken),
+    searchParams,
   });
 
-  if (response.status === 401) {
+  if (response.statusCode === 401) {
     throw sharedMessages.createError('error.authorization');
   }
 
-  if (response.status === 400) {
-    const body = (await response.json()) as { error: string };
+  if (response.statusCode === 400) {
+    const body = response.body as { error: string };
     if (body.error === 'no_pool') {
       throw sharedMessages.createError('error.noPool');
     }
     throw sharedMessages.createError('error.serverError');
   }
 
-  if (response.status === 404) {
-    const body = (await response.json()) as { error: string };
+  if (response.statusCode === 404) {
+    const body = response.body as { error: string };
     if (body.error === 'no_active_org') {
       throw sharedMessages.createError('error.noActiveOrg');
     }
     throw sharedMessages.createError('error.serverError');
   }
 
-  if (!response.ok) {
+  if (response.statusCode < 200 || response.statusCode >= 300) {
     throw sharedMessages.createError('error.serverError');
   }
 
-  const body = (await response.json()) as { data: IScratchOrgResponse };
-  return mapScratchOrg(body.data);
+  return mapScratchOrg(response.body.data);
 }
 
 async function terminateOrg(apiToken: string, project: ResolvedProject, orgId: string): Promise<void> {
-  const url = new URL(apiUrl(`/scratch_orgs/${orgId}/terminate`));
-  setProjectParams(url, project);
-
-  const response = await apiFetch(url.toString(), {
-    method: 'POST',
+  const response = await apiRequest('post', `scratch_orgs/${orgId}/terminate`, {
     headers: authHeaders(apiToken),
+    searchParams: projectParams(project),
   });
 
-  if (response.status === 404) {
+  if (response.statusCode === 404) {
     throw sharedMessages.createError('error.orgNotFoundOnHutte');
   }
 
-  if (response.status === 401) {
+  if (response.statusCode === 401) {
     throw sharedMessages.createError('error.authorization');
   }
 
-  if (!response.ok) {
+  if (response.statusCode < 200 || response.statusCode >= 300) {
     throw sharedMessages.createError('error.serverError');
   }
 }
@@ -273,25 +271,23 @@ type IUserResponse = {
 };
 
 async function getMe(apiToken: string): Promise<IUser> {
-  const response = await apiFetch(apiUrl('/me'), {
-    method: 'GET',
+  const response = await apiRequest<{ data: IUserResponse }>('get', 'me', {
     headers: authHeaders(apiToken),
   });
 
-  if (response.status === 401) {
+  if (response.statusCode === 401) {
     throw sharedMessages.createError('error.authorization');
   }
 
-  if (!response.ok) {
+  if (response.statusCode < 200 || response.statusCode >= 300) {
     throw sharedMessages.createError('error.serverError');
   }
 
-  const body = (await response.json()) as { data: IUserResponse };
   return {
-    id: body.data.id,
-    name: body.data.name,
-    email: body.data.email,
-    organizationName: body.data.organization_name,
+    id: response.body.data.id,
+    name: response.body.data.name,
+    email: response.body.data.email,
+    organizationName: response.body.data.organization_name,
   };
 }
 
@@ -312,8 +308,6 @@ type ICreateScratchOrgRequestBody = {
 };
 
 async function createScratchOrg(apiToken: string, request: ICreateScratchOrgRequest): Promise<IScratchOrg> {
-  const url = new URL(apiUrl('/scratch_orgs'));
-
   /* eslint-disable camelcase */
   const body: ICreateScratchOrgRequestBody = {
     name: request.name,
@@ -331,55 +325,49 @@ async function createScratchOrg(apiToken: string, request: ICreateScratchOrgRequ
   if (request.configJson) body.config_json = request.configJson;
   /* eslint-enable camelcase */
 
-  const response = await apiFetch(url.toString(), {
-    method: 'POST',
+  const response = await apiRequest<{ data: IScratchOrgResponse; error?: string }>('post', 'scratch_orgs', {
     headers: {
       ...authHeaders(apiToken),
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(body),
+    json: body,
   });
 
-  if (response.status === 401) {
+  if (response.statusCode === 401) {
     throw sharedMessages.createError('error.authorization');
   }
 
-  if (response.status === 400 || response.status === 422) {
-    const errorBody = (await response.json()) as { error?: string };
+  if (response.statusCode === 400 || response.statusCode === 422) {
+    const errorBody = response.body as { error?: string };
     throw sharedMessages.createError('error.badRequest', [errorBody.error ?? 'Bad request']);
   }
 
-  if (!response.ok) {
+  if (response.statusCode < 200 || response.statusCode >= 300) {
     throw sharedMessages.createError('error.serverError');
   }
 
-  const responseBody = (await response.json()) as { data: IScratchOrgResponse };
-  return mapScratchOrg(responseBody.data);
+  return mapScratchOrg(response.body.data);
 }
 
 async function getScratchOrg(apiToken: string, project: ResolvedProject, orgId: string): Promise<IScratchOrg> {
-  const url = new URL(apiUrl(`/scratch_orgs/${orgId}`));
-  setProjectParams(url, project);
-
-  const response = await apiFetch(url.toString(), {
-    method: 'GET',
+  const response = await apiRequest<{ data: IScratchOrgResponse }>('get', `scratch_orgs/${orgId}`, {
     headers: authHeaders(apiToken),
+    searchParams: projectParams(project),
   });
 
-  if (response.status === 401) {
+  if (response.statusCode === 401) {
     throw sharedMessages.createError('error.authorization');
   }
 
-  if (response.status === 404) {
+  if (response.statusCode === 404) {
     throw sharedMessages.createError('error.orgNotFoundOnHutte');
   }
 
-  if (!response.ok) {
+  if (response.statusCode < 200 || response.statusCode >= 300) {
     throw sharedMessages.createError('error.serverError');
   }
 
-  const responseBody = (await response.json()) as { data: IScratchOrgResponse };
-  return mapScratchOrg(responseBody.data);
+  return mapScratchOrg(response.body.data);
 }
 
 export default {

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -1,0 +1,55 @@
+import got, { type Got } from 'got';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+
+const API_BASE_URL = 'https://api.hutte.io/cli_api';
+const API_HOST = 'api.hutte.io';
+
+let client: Got | undefined;
+
+function getProxyUrl(): string | undefined {
+  return process.env.HTTPS_PROXY ?? process.env.https_proxy ?? process.env.HTTP_PROXY ?? process.env.http_proxy;
+}
+
+function isProxyBypassed(noProxy: string): boolean {
+  const entries = noProxy.split(',').map((e) => e.trim());
+  for (const entry of entries) {
+    if (entry === '*') return true;
+    if (entry === API_HOST) return true;
+    if (entry.startsWith('.') && API_HOST.endsWith(entry)) return true;
+  }
+  return false;
+}
+
+function buildProxyAgent(): { https: HttpsProxyAgent<string> } | undefined {
+  const proxyUrl = getProxyUrl();
+  if (!proxyUrl) return undefined;
+
+  const noProxy = process.env.NO_PROXY ?? process.env.no_proxy;
+  if (noProxy && isProxyBypassed(noProxy)) return undefined;
+
+  return { https: new HttpsProxyAgent(proxyUrl) };
+}
+
+function createHttpClient(): Got {
+  return got.extend({
+    prefixUrl: API_BASE_URL,
+    throwHttpErrors: false,
+    responseType: 'json',
+    agent: buildProxyAgent(),
+  });
+}
+
+export function getHttpClient(): Got {
+  if (!client) {
+    client = createHttpClient();
+  }
+  return client;
+}
+
+export function setHttpClient(c: Got): void {
+  client = c;
+}
+
+export function resetHttpClient(): void {
+  client = undefined;
+}

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -2,33 +2,34 @@
 import { expect } from 'chai';
 import sinon, { type SinonStub } from 'sinon';
 import { SfError } from '@salesforce/core';
+import { type Got, RequestError } from 'got';
 import api, { type IScratchOrgResponse } from '../src/api.js';
+import { setHttpClient, resetHttpClient } from '../src/http-client.js';
 import { type ResolvedProject } from '../src/types.js';
 
 const gitProject = (repoName: string): ResolvedProject => ({ repoName, source: 'git' });
 
 describe('api', () => {
-  let fetchStub: SinonStub;
+  let clientStub: SinonStub;
 
   beforeEach(() => {
-    fetchStub = sinon.stub(global, 'fetch');
+    clientStub = sinon.stub();
+    setHttpClient(clientStub as unknown as Got);
   });
 
   afterEach(() => {
+    resetHttpClient();
     sinon.restore();
   });
 
-  const mockResponse = (status: number, body: unknown = {}): Response =>
-    ({
-      ok: status >= 200 && status < 300,
-      status,
-      json: () => Promise.resolve(body),
-      text: () => Promise.resolve(JSON.stringify(body)),
-    } as Response);
+  const mockResponse = (statusCode: number, body: unknown = {}): { statusCode: number; body: unknown } => ({
+    statusCode,
+    body,
+  });
 
   describe('login', () => {
     it('returns userId and apiToken on success', async () => {
-      fetchStub.resolves(
+      clientStub.resolves(
         mockResponse(200, {
           data: { api_token: 'token123', user_id: 'user456' },
         })
@@ -38,20 +39,19 @@ describe('api', () => {
 
       expect(result.apiToken).to.equal('token123');
       expect(result.userId).to.equal('user456');
-      expect(fetchStub.calledOnce).to.equal(true);
+      expect(clientStub.calledOnce).to.equal(true);
 
-      const callArgs = fetchStub.firstCall.args as [string, RequestInit];
-      const [url, options] = callArgs;
-      expect(url).to.include('/api_tokens');
-      expect(options.method).to.equal('POST');
-      expect(JSON.parse(options.body as string)).to.deep.equal({
+      const [path, options] = clientStub.firstCall.args as [string, Record<string, unknown>];
+      expect(path).to.equal('api_tokens');
+      expect(options.method).to.equal('post');
+      expect(options.json).to.deep.equal({
         email: 'test@example.com',
         password: 'password123',
       });
     });
 
     it('throws authorization error on 401', async () => {
-      fetchStub.resolves(mockResponse(401));
+      clientStub.resolves(mockResponse(401));
 
       try {
         await api.login('test@example.com', 'wrongpassword');
@@ -63,7 +63,7 @@ describe('api', () => {
     });
 
     it('throws authorization error on 400', async () => {
-      fetchStub.resolves(mockResponse(400));
+      clientStub.resolves(mockResponse(400));
 
       try {
         await api.login('test@example.com', 'password');
@@ -74,9 +74,9 @@ describe('api', () => {
       }
     });
 
-    it('throws network error when fetch fails', async () => {
-      const networkError = new TypeError('fetch failed');
-      fetchStub.rejects(networkError);
+    it('throws network error when request fails', async () => {
+      const networkError = new RequestError('getaddrinfo ENOTFOUND api.hutte.io', {}, undefined as never);
+      clientStub.rejects(networkError);
 
       try {
         await api.login('test@example.com', 'password');
@@ -113,7 +113,7 @@ describe('api', () => {
     };
 
     it('returns mapped scratch orgs on success', async () => {
-      fetchStub.resolves(mockResponse(200, { data: [mockOrgData] }));
+      clientStub.resolves(mockResponse(200, { data: [mockOrgData] }));
 
       const result = await api.getScratchOrgs('token123', gitProject('my-repo'));
 
@@ -123,24 +123,22 @@ describe('api', () => {
       expect(result[0].orgName).to.equal('My Org');
       expect(result[0].remainingDays).to.equal(7);
 
-      const callArgs = fetchStub.firstCall.args as [string, RequestInit];
-      const [url] = callArgs;
-      expect(url).to.include('/scratch_orgs');
-      expect(url).to.include('repo_name=my-repo');
+      const [path, options] = clientStub.firstCall.args as [string, Record<string, unknown>];
+      expect(path).to.equal('scratch_orgs');
+      expect((options.searchParams as Record<string, string>).repo_name).to.equal('my-repo');
     });
 
     it('passes includeAll parameter', async () => {
-      fetchStub.resolves(mockResponse(200, { data: [] }));
+      clientStub.resolves(mockResponse(200, { data: [] }));
 
       await api.getScratchOrgs('token123', gitProject('my-repo'), true);
 
-      const callArgs = fetchStub.firstCall.args as [string, RequestInit];
-      const [url] = callArgs;
-      expect(url).to.include('all=true');
+      const [, options] = clientStub.firstCall.args as [string, Record<string, unknown>];
+      expect((options.searchParams as Record<string, string>).all).to.equal('true');
     });
 
     it('throws authorization error on 401', async () => {
-      fetchStub.resolves(mockResponse(401));
+      clientStub.resolves(mockResponse(401));
 
       try {
         await api.getScratchOrgs('invalid-token', gitProject('my-repo'));
@@ -152,7 +150,7 @@ describe('api', () => {
     });
 
     it('throws server error on 500', async () => {
-      fetchStub.resolves(mockResponse(500));
+      clientStub.resolves(mockResponse(500));
 
       try {
         await api.getScratchOrgs('token123', gitProject('my-repo'));
@@ -164,7 +162,7 @@ describe('api', () => {
     });
 
     it('throws server error on 503', async () => {
-      fetchStub.resolves(mockResponse(503));
+      clientStub.resolves(mockResponse(503));
 
       try {
         await api.getScratchOrgs('token123', gitProject('my-repo'));
@@ -175,8 +173,8 @@ describe('api', () => {
       }
     });
 
-    it('throws network error when fetch fails', async () => {
-      fetchStub.rejects(new TypeError('fetch failed'));
+    it('throws network error when request fails', async () => {
+      clientStub.rejects(new RequestError('fetch failed', {}, undefined as never));
 
       try {
         await api.getScratchOrgs('token123', gitProject('my-repo'));
@@ -212,7 +210,7 @@ describe('api', () => {
     };
 
     it('returns mapped scratch org on success', async () => {
-      fetchStub.resolves(mockResponse(200, { data: mockOrgData }));
+      clientStub.resolves(mockResponse(200, { data: mockOrgData }));
 
       const result = await api.takeOrgFromPool('token123', gitProject('my-repo'));
 
@@ -220,34 +218,31 @@ describe('api', () => {
       expect(result.orgName).to.equal('Pool Org');
       expect(result.pool).to.equal(true);
 
-      const callArgs = fetchStub.firstCall.args as [string, RequestInit];
-      const [url, options] = callArgs;
-      expect(url).to.include('/take_from_pool');
-      expect(options.method).to.equal('POST');
+      const [path, options] = clientStub.firstCall.args as [string, Record<string, unknown>];
+      expect(path).to.equal('take_from_pool');
+      expect(options.method).to.equal('post');
     });
 
     it('passes orgName parameter', async () => {
-      fetchStub.resolves(mockResponse(200, { data: mockOrgData }));
+      clientStub.resolves(mockResponse(200, { data: mockOrgData }));
 
       await api.takeOrgFromPool('token123', gitProject('my-repo'), 'my-org-name');
 
-      const callArgs = fetchStub.firstCall.args as [string, RequestInit];
-      const [url] = callArgs;
-      expect(url).to.include('name=my-org-name');
+      const [, options] = clientStub.firstCall.args as [string, Record<string, unknown>];
+      expect((options.searchParams as Record<string, string>).name).to.equal('my-org-name');
     });
 
     it('passes projectId parameter', async () => {
-      fetchStub.resolves(mockResponse(200, { data: mockOrgData }));
+      clientStub.resolves(mockResponse(200, { data: mockOrgData }));
 
       await api.takeOrgFromPool('token123', { repoName: 'my-repo', projectId: 'project-123', source: 'flag' });
 
-      const callArgs = fetchStub.firstCall.args as [string, RequestInit];
-      const [url] = callArgs;
-      expect(url).to.include('project_id=project-123');
+      const [, options] = clientStub.firstCall.args as [string, Record<string, unknown>];
+      expect((options.searchParams as Record<string, string>).project_id).to.equal('project-123');
     });
 
     it('throws authorization error on 401', async () => {
-      fetchStub.resolves(mockResponse(401));
+      clientStub.resolves(mockResponse(401));
 
       try {
         await api.takeOrgFromPool('invalid-token', gitProject('my-repo'));
@@ -259,7 +254,7 @@ describe('api', () => {
     });
 
     it('throws noPool error on 400 with no_pool', async () => {
-      fetchStub.resolves(mockResponse(400, { error: 'no_pool' }));
+      clientStub.resolves(mockResponse(400, { error: 'no_pool' }));
 
       try {
         await api.takeOrgFromPool('token123', gitProject('my-repo'));
@@ -271,7 +266,7 @@ describe('api', () => {
     });
 
     it('throws server error on 400 with unknown error', async () => {
-      fetchStub.resolves(mockResponse(400, { error: 'unknown_error' }));
+      clientStub.resolves(mockResponse(400, { error: 'unknown_error' }));
 
       try {
         await api.takeOrgFromPool('token123', gitProject('my-repo'));
@@ -283,7 +278,7 @@ describe('api', () => {
     });
 
     it('throws noActiveOrg error on 404 with no_active_org', async () => {
-      fetchStub.resolves(mockResponse(404, { error: 'no_active_org' }));
+      clientStub.resolves(mockResponse(404, { error: 'no_active_org' }));
 
       try {
         await api.takeOrgFromPool('token123', gitProject('my-repo'));
@@ -295,7 +290,7 @@ describe('api', () => {
     });
 
     it('throws server error on 404 with unknown error', async () => {
-      fetchStub.resolves(mockResponse(404, { error: 'other_error' }));
+      clientStub.resolves(mockResponse(404, { error: 'other_error' }));
 
       try {
         await api.takeOrgFromPool('token123', gitProject('my-repo'));
@@ -307,7 +302,7 @@ describe('api', () => {
     });
 
     it('throws server error on 500', async () => {
-      fetchStub.resolves(mockResponse(500));
+      clientStub.resolves(mockResponse(500));
 
       try {
         await api.takeOrgFromPool('token123', gitProject('my-repo'));
@@ -318,8 +313,8 @@ describe('api', () => {
       }
     });
 
-    it('throws network error when fetch fails', async () => {
-      fetchStub.rejects(new TypeError('fetch failed'));
+    it('throws network error when request fails', async () => {
+      clientStub.rejects(new RequestError('fetch failed', {}, undefined as never));
 
       try {
         await api.takeOrgFromPool('token123', gitProject('my-repo'));
@@ -355,7 +350,7 @@ describe('api', () => {
         web_url: 'https://app.hutte.io/scratch-orgs/gid1',
       };
 
-      fetchStub.resolves(mockResponse(200, { data: mockOrgResponse }));
+      clientStub.resolves(mockResponse(200, { data: mockOrgResponse }));
 
       const result = await api.createScratchOrg('token123', {
         project: gitProject('my-repo'),
@@ -366,18 +361,17 @@ describe('api', () => {
       expect(result.orgName).to.equal('New Org');
       expect(result.state).to.equal('creating');
 
-      const callArgs = fetchStub.firstCall.args as [string, RequestInit];
-      const [url, options] = callArgs;
-      expect(url).to.include('/scratch_orgs');
-      expect(options.method).to.equal('POST');
+      const [path, options] = clientStub.firstCall.args as [string, Record<string, unknown>];
+      expect(path).to.equal('scratch_orgs');
+      expect(options.method).to.equal('post');
 
-      const body = JSON.parse(options.body as string) as Record<string, unknown>;
+      const body = options.json as Record<string, unknown>;
       expect(body.repo_name).to.equal('my-repo');
       expect(body.name).to.equal('New Org');
     });
 
     it('passes project_id when resolved by project ID', async () => {
-      fetchStub.resolves(
+      clientStub.resolves(
         mockResponse(200, {
           data: {
             id: 'org1',
@@ -408,14 +402,14 @@ describe('api', () => {
         name: 'Test Org',
       });
 
-      const callArgs = fetchStub.firstCall.args as [string, RequestInit];
-      const body = JSON.parse(callArgs[1].body as string) as Record<string, unknown>;
+      const [, options] = clientStub.firstCall.args as [string, Record<string, unknown>];
+      const body = options.json as Record<string, unknown>;
       expect(body.project_id).to.equal('project-123');
       expect(body.repo_name).to.equal('my-repo');
     });
 
     it('passes optional fields', async () => {
-      fetchStub.resolves(
+      clientStub.resolves(
         mockResponse(200, {
           data: {
             id: 'org1',
@@ -453,8 +447,8 @@ describe('api', () => {
         notes: 'test notes',
       });
 
-      const callArgs = fetchStub.firstCall.args as [string, RequestInit];
-      const body = JSON.parse(callArgs[1].body as string) as Record<string, unknown>;
+      const [, options] = clientStub.firstCall.args as [string, Record<string, unknown>];
+      const body = options.json as Record<string, unknown>;
       expect(body.initial_branch_name).to.equal('develop');
       expect(body.duration_days).to.equal(14);
       expect(body.branch_name).to.equal('feature/test');
@@ -465,7 +459,7 @@ describe('api', () => {
     });
 
     it('throws authorization error on 401', async () => {
-      fetchStub.resolves(mockResponse(401));
+      clientStub.resolves(mockResponse(401));
 
       try {
         await api.createScratchOrg('invalid-token', { project: gitProject('my-repo'), name: 'Test' });
@@ -477,7 +471,7 @@ describe('api', () => {
     });
 
     it('throws bad request error on 400', async () => {
-      fetchStub.resolves(mockResponse(400, { error: 'Invalid config' }));
+      clientStub.resolves(mockResponse(400, { error: 'Invalid config' }));
 
       try {
         await api.createScratchOrg('token123', { project: gitProject('my-repo'), name: 'Test' });
@@ -489,7 +483,7 @@ describe('api', () => {
     });
 
     it('throws server error on 500', async () => {
-      fetchStub.resolves(mockResponse(500));
+      clientStub.resolves(mockResponse(500));
 
       try {
         await api.createScratchOrg('token123', { project: gitProject('my-repo'), name: 'Test' });
@@ -525,21 +519,20 @@ describe('api', () => {
         web_url: 'https://app.hutte.io/scratch-orgs/gid1',
       };
 
-      fetchStub.resolves(mockResponse(200, { data: mockOrgResponse }));
+      clientStub.resolves(mockResponse(200, { data: mockOrgResponse }));
 
       const result = await api.getScratchOrg('token123', gitProject('my-repo'), 'org1');
 
       expect(result.id).to.equal('org1');
       expect(result.orgName).to.equal('My Org');
 
-      const callArgs = fetchStub.firstCall.args as [string, RequestInit];
-      const [url] = callArgs;
-      expect(url).to.include('/scratch_orgs/org1');
-      expect(url).to.include('repo_name=my-repo');
+      const [path, options] = clientStub.firstCall.args as [string, Record<string, unknown>];
+      expect(path).to.equal('scratch_orgs/org1');
+      expect((options.searchParams as Record<string, string>).repo_name).to.equal('my-repo');
     });
 
     it('passes project_id parameter', async () => {
-      fetchStub.resolves(
+      clientStub.resolves(
         mockResponse(200, {
           data: {
             id: 'org1',
@@ -567,13 +560,12 @@ describe('api', () => {
 
       await api.getScratchOrg('token123', { repoName: 'my-repo', projectId: 'project-123', source: 'flag' }, 'org1');
 
-      const callArgs = fetchStub.firstCall.args as [string, RequestInit];
-      const [url] = callArgs;
-      expect(url).to.include('project_id=project-123');
+      const [, options] = clientStub.firstCall.args as [string, Record<string, unknown>];
+      expect((options.searchParams as Record<string, string>).project_id).to.equal('project-123');
     });
 
     it('throws authorization error on 401', async () => {
-      fetchStub.resolves(mockResponse(401));
+      clientStub.resolves(mockResponse(401));
 
       try {
         await api.getScratchOrg('invalid-token', gitProject('my-repo'), 'org1');
@@ -585,7 +577,7 @@ describe('api', () => {
     });
 
     it('throws orgNotFoundOnHutte error on 404', async () => {
-      fetchStub.resolves(mockResponse(404));
+      clientStub.resolves(mockResponse(404));
 
       try {
         await api.getScratchOrg('token123', gitProject('my-repo'), 'nonexistent');
@@ -597,7 +589,7 @@ describe('api', () => {
     });
 
     it('throws server error on 500', async () => {
-      fetchStub.resolves(mockResponse(500));
+      clientStub.resolves(mockResponse(500));
 
       try {
         await api.getScratchOrg('token123', gitProject('my-repo'), 'org1');
@@ -608,8 +600,8 @@ describe('api', () => {
       }
     });
 
-    it('throws network error when fetch fails', async () => {
-      fetchStub.rejects(new TypeError('fetch failed'));
+    it('throws network error when request fails', async () => {
+      clientStub.rejects(new RequestError('fetch failed', {}, undefined as never));
 
       try {
         await api.getScratchOrg('token123', gitProject('my-repo'), 'org1');
@@ -623,29 +615,27 @@ describe('api', () => {
 
   describe('terminateOrg', () => {
     it('resolves on success', async () => {
-      fetchStub.resolves(mockResponse(200));
+      clientStub.resolves(mockResponse(200));
 
       await api.terminateOrg('token123', gitProject('my-repo'), 'org-id');
 
-      const callArgs = fetchStub.firstCall.args as [string, RequestInit];
-      const [url, options] = callArgs;
-      expect(url).to.include('/scratch_orgs/org-id/terminate');
-      expect(url).to.include('repo_name=my-repo');
-      expect(options.method).to.equal('POST');
+      const [path, options] = clientStub.firstCall.args as [string, Record<string, unknown>];
+      expect(path).to.equal('scratch_orgs/org-id/terminate');
+      expect((options.searchParams as Record<string, string>).repo_name).to.equal('my-repo');
+      expect(options.method).to.equal('post');
     });
 
     it('passes projectId parameter', async () => {
-      fetchStub.resolves(mockResponse(200));
+      clientStub.resolves(mockResponse(200));
 
       await api.terminateOrg('token123', { repoName: 'my-repo', projectId: 'project-123', source: 'flag' }, 'org-id');
 
-      const callArgs = fetchStub.firstCall.args as [string, RequestInit];
-      const [url] = callArgs;
-      expect(url).to.include('project_id=project-123');
+      const [, options] = clientStub.firstCall.args as [string, Record<string, unknown>];
+      expect((options.searchParams as Record<string, string>).project_id).to.equal('project-123');
     });
 
     it('throws orgNotFoundOnHutte error on 404', async () => {
-      fetchStub.resolves(mockResponse(404));
+      clientStub.resolves(mockResponse(404));
 
       try {
         await api.terminateOrg('token123', gitProject('my-repo'), 'nonexistent-org');
@@ -657,7 +647,7 @@ describe('api', () => {
     });
 
     it('throws authorization error on 401', async () => {
-      fetchStub.resolves(mockResponse(401));
+      clientStub.resolves(mockResponse(401));
 
       try {
         await api.terminateOrg('invalid-token', gitProject('my-repo'), 'org-id');
@@ -669,7 +659,7 @@ describe('api', () => {
     });
 
     it('throws server error on 500', async () => {
-      fetchStub.resolves(mockResponse(500));
+      clientStub.resolves(mockResponse(500));
 
       try {
         await api.terminateOrg('token123', gitProject('my-repo'), 'org-id');
@@ -681,7 +671,7 @@ describe('api', () => {
     });
 
     it('throws server error on 503', async () => {
-      fetchStub.resolves(mockResponse(503));
+      clientStub.resolves(mockResponse(503));
 
       try {
         await api.terminateOrg('token123', gitProject('my-repo'), 'org-id');
@@ -692,8 +682,8 @@ describe('api', () => {
       }
     });
 
-    it('throws network error when fetch fails', async () => {
-      fetchStub.rejects(new TypeError('fetch failed'));
+    it('throws network error when request fails', async () => {
+      clientStub.rejects(new RequestError('fetch failed', {}, undefined as never));
 
       try {
         await api.terminateOrg('token123', gitProject('my-repo'), 'org-id');

--- a/test/http-client.test.ts
+++ b/test/http-client.test.ts
@@ -1,0 +1,129 @@
+/* eslint-disable no-unused-expressions, camelcase */
+import { expect } from 'chai';
+import { getHttpClient, resetHttpClient } from '../src/http-client.js';
+
+describe('http-client', () => {
+  const envVars = ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy', 'NO_PROXY', 'no_proxy'];
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of envVars) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    resetHttpClient();
+  });
+
+  afterEach(() => {
+    for (const key of envVars) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+    resetHttpClient();
+  });
+
+  it('returns a got instance with correct prefixUrl', () => {
+    const client = getHttpClient();
+    expect(client.defaults.options.prefixUrl).to.equal('https://api.hutte.io/cli_api/');
+  });
+
+  it('returns a singleton instance', () => {
+    const client1 = getHttpClient();
+    const client2 = getHttpClient();
+    expect(client1).to.equal(client2);
+  });
+
+  it('returns new instance after reset', () => {
+    const client1 = getHttpClient();
+    resetHttpClient();
+    const client2 = getHttpClient();
+    expect(client1).to.not.equal(client2);
+  });
+
+  it('does not configure agent when no proxy env vars are set', () => {
+    const client = getHttpClient();
+    const agent = client.defaults.options.agent;
+    expect(agent.https).to.be.undefined;
+  });
+
+  it('configures HttpsProxyAgent when HTTPS_PROXY is set', () => {
+    process.env.HTTPS_PROXY = 'http://proxy:8080';
+    const client = getHttpClient();
+    const agent = client.defaults.options.agent;
+    expect(agent.https).to.not.be.undefined;
+    expect(agent.https!.constructor.name).to.equal('HttpsProxyAgent');
+  });
+
+  it('falls back to HTTP_PROXY when HTTPS_PROXY is not set', () => {
+    process.env.HTTP_PROXY = 'http://proxy:3128';
+    const client = getHttpClient();
+    const agent = client.defaults.options.agent;
+    expect(agent.https).to.not.be.undefined;
+    expect(agent.https!.constructor.name).to.equal('HttpsProxyAgent');
+  });
+
+  it('uses lowercase https_proxy', () => {
+    process.env.https_proxy = 'http://proxy:8080';
+    const client = getHttpClient();
+    const agent = client.defaults.options.agent;
+    expect(agent.https).to.not.be.undefined;
+  });
+
+  it('uses lowercase http_proxy as fallback', () => {
+    process.env.http_proxy = 'http://proxy:8080';
+    const client = getHttpClient();
+    const agent = client.defaults.options.agent;
+    expect(agent.https).to.not.be.undefined;
+  });
+
+  it('bypasses proxy when NO_PROXY matches exact host', () => {
+    process.env.HTTPS_PROXY = 'http://proxy:8080';
+    process.env.NO_PROXY = 'api.hutte.io';
+    const client = getHttpClient();
+    const agent = client.defaults.options.agent;
+    expect(agent.https).to.be.undefined;
+  });
+
+  it('bypasses proxy when NO_PROXY matches domain wildcard', () => {
+    process.env.HTTPS_PROXY = 'http://proxy:8080';
+    process.env.NO_PROXY = '.hutte.io';
+    const client = getHttpClient();
+    const agent = client.defaults.options.agent;
+    expect(agent.https).to.be.undefined;
+  });
+
+  it('bypasses proxy when NO_PROXY is *', () => {
+    process.env.HTTPS_PROXY = 'http://proxy:8080';
+    process.env.NO_PROXY = '*';
+    const client = getHttpClient();
+    const agent = client.defaults.options.agent;
+    expect(agent.https).to.be.undefined;
+  });
+
+  it('does not bypass proxy when NO_PROXY does not match', () => {
+    process.env.HTTPS_PROXY = 'http://proxy:8080';
+    process.env.NO_PROXY = 'other.example.com';
+    const client = getHttpClient();
+    const agent = client.defaults.options.agent;
+    expect(agent.https).to.not.be.undefined;
+  });
+
+  it('handles comma-separated NO_PROXY list', () => {
+    process.env.HTTPS_PROXY = 'http://proxy:8080';
+    process.env.NO_PROXY = 'example.com, api.hutte.io, other.com';
+    const client = getHttpClient();
+    const agent = client.defaults.options.agent;
+    expect(agent.https).to.be.undefined;
+  });
+
+  it('uses lowercase no_proxy', () => {
+    process.env.HTTPS_PROXY = 'http://proxy:8080';
+    process.env.no_proxy = 'api.hutte.io';
+    const client = getHttpClient();
+    const agent = client.defaults.options.agent;
+    expect(agent.https).to.be.undefined;
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4699,7 +4699,7 @@ gopd@^1.0.1, gopd@^1.2.0:
   resolved "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
-got@^13:
+got@^13, got@^13.0.0:
   version "13.0.0"
   resolved "https://registry.npmjs.org/got/-/got-13.0.0.tgz"
   integrity sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==
@@ -4906,7 +4906,7 @@ https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
-https-proxy-agent@^7.0.1:
+https-proxy-agent@^7.0.0, https-proxy-agent@^7.0.1:
   version "7.0.6"
   resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz"
   integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==


### PR DESCRIPTION
## Summary

- Add HTTP proxy support via `HTTPS_PROXY` / `HTTP_PROXY` environment variables
- Support `NO_PROXY` for bypassing proxy on specific hosts
- Replace `fetch` with `got` + `https-proxy-agent` for reliable proxy handling