### PR TITLE
feat: add sandbox list and authorize commands

### DIFF
--- a/messages/hutte.common.md
+++ b/messages/hutte.common.md
@@ -13,3 +13,7 @@ Error reading the default scratch org.
 # error.pollTimeout
 
 Timed out waiting for scratch org to be ready.
+
+# error.sandboxLoginFailed
+
+Failed to log in to the sandbox: %s

--- a/messages/hutte.sandbox.authorize.md
+++ b/messages/hutte.sandbox.authorize.md
@@ -1,0 +1,32 @@
+# summary
+
+Authorize (log in to) a Hutte sandbox. Only project admins can authorize sandboxes.
+
+# flags.sandbox-name.summary
+
+The name of the sandbox to authorize.
+
+# error.sandboxNotFound
+
+There is not any sandbox to authorize by the provided name.
+
+# error.sandboxNotFound.actions
+
+- Remove the --sandbox-name flag to choose from a list.
+- Visit https://app.hutte.io to see available sandboxes.
+
+# error.noSandboxesToAuthorize
+
+You don't have any sandboxes to authorize.
+
+# error.noSandboxesToAuthorize.actions
+
+- Visit https://app.hutte.io to see available sandboxes.
+
+# error.noSandboxSelected
+
+No sandbox selected.
+
+# prompt.chooseSandbox
+
+Which sandbox would you like to authorize?

--- a/messages/hutte.sandbox.authorize.md
+++ b/messages/hutte.sandbox.authorize.md
@@ -21,3 +21,19 @@ No sandbox selected.
 # prompt.chooseSandbox
 
 Which sandbox would you like to authorize?
+
+# spinner.authorizing
+
+Authorizing sandbox %s
+
+# success.authorized
+
+Authorized sandbox %s (alias %s, set as the default org).
+
+# success.authorizedAs
+
+Authorized sandbox %s as %s (alias %s, set as the default org).
+
+# info.autoSelected
+
+Only one sandbox found — authorizing %s.

--- a/messages/hutte.sandbox.authorize.md
+++ b/messages/hutte.sandbox.authorize.md
@@ -6,15 +6,6 @@ Authorize (log in to) a Hutte sandbox. Only project admins can authorize sandbox
 
 The name of the sandbox to authorize.
 
-# error.sandboxNotFound
-
-There is not any sandbox to authorize by the provided name.
-
-# error.sandboxNotFound.actions
-
-- Remove the --sandbox-name flag to choose from a list.
-- Visit https://app.hutte.io to see available sandboxes.
-
 # error.noSandboxesToAuthorize
 
 You don't have any sandboxes to authorize.

--- a/messages/hutte.sandbox.list.md
+++ b/messages/hutte.sandbox.list.md
@@ -1,0 +1,3 @@
+# summary
+
+List the sandboxes of a Hutte project.

--- a/messages/shared.md
+++ b/messages/shared.md
@@ -99,3 +99,12 @@ Hutte could not generate an auth URL for this sandbox.
 # error.sandboxAuthUrlUnavailable.actions
 
 - The sandbox may need to be reconnected. Check it at https://app.hutte.io.
+
+# error.sandboxNotFound
+
+Could not find a sandbox with that name in this project.
+
+# error.sandboxNotFound.actions
+
+- Run `sf hutte sandbox list` to see available sandboxes.
+- Or omit --sandbox-name to choose from a list.

--- a/messages/shared.md
+++ b/messages/shared.md
@@ -91,3 +91,11 @@ Only project admins can authorize sandboxes.
 # error.sandboxNotFoundOnHutte
 
 Could not find the sandbox on Hutte. Are you sure you are in the correct project?
+
+# error.sandboxAuthUrlUnavailable
+
+Hutte could not generate an auth URL for this sandbox.
+
+# error.sandboxAuthUrlUnavailable.actions
+
+- The sandbox may need to be reconnected. Check it at https://app.hutte.io.

--- a/messages/shared.md
+++ b/messages/shared.md
@@ -79,3 +79,15 @@ Remote branch does not exist. Creating based on %s...
 # spinner.pulling
 
 Pulling source from scratch org
+
+# error.sandboxAuthorizeForbidden
+
+Only project admins can authorize sandboxes.
+
+# error.sandboxAuthorizeForbidden.actions
+
+- Ask a project admin to authorize the sandbox, or request project admin access at https://app.hutte.io.
+
+# error.sandboxNotFoundOnHutte
+
+Could not find the sandbox on Hutte. Are you sure you are in the correct project?

--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
       },
       "hutte project": {
         "description": "manage Hutte project configuration"
+      },
+      "hutte sandbox": {
+        "description": "manage Hutte sandboxes"
       }
     },
     "additionalHelpFlags": [

--- a/src/api.ts
+++ b/src/api.ts
@@ -156,6 +156,57 @@ function mapScratchOrg(org: IScratchOrgResponse): IScratchOrg {
   };
 }
 
+export type ISalesforceUser = {
+  id: string;
+  name: string;
+};
+
+export type ISandbox = {
+  id: string;
+  name: string;
+  displayName: string | null;
+  projectId: string;
+  projectName: string;
+  pool: boolean;
+  licenseType: string | null;
+  createSandboxFrom: string | null;
+  salesforceUser: ISalesforceUser | null;
+  salesforceStatus: string;
+  lastRefreshedAt: string | null;
+};
+
+type ISandboxResponse = {
+  /* eslint-disable camelcase */
+  id: string;
+  name: string;
+  display_name: string | null;
+  project_id: string;
+  project_name: string;
+  pool: boolean;
+  license_type: string | null;
+  create_sandbox_from: string | null;
+  salesforce_user: { id: string; name: string } | null;
+  salesforce_status: string;
+  last_refreshed_at: string | null;
+  /* eslint-enable camelcase */
+};
+
+function mapSandbox(sandbox: ISandboxResponse): ISandbox {
+  return {
+    id: sandbox.id,
+    name: sandbox.name,
+    displayName: sandbox.display_name,
+    projectId: sandbox.project_id,
+    projectName: sandbox.project_name,
+    pool: sandbox.pool,
+    licenseType: sandbox.license_type,
+    createSandboxFrom: sandbox.create_sandbox_from,
+    salesforceUser: sandbox.salesforce_user,
+    salesforceStatus: sandbox.salesforce_status,
+    lastRefreshedAt: sandbox.last_refreshed_at,
+  };
+}
+
 async function getProjects(apiToken: string): Promise<IProject[]> {
   const response = await apiRequest<{ data: IProjectResponse[] }>('get', 'projects', {
     headers: authHeaders(apiToken),
@@ -370,6 +421,47 @@ async function getScratchOrg(apiToken: string, project: ResolvedProject, orgId: 
   return mapScratchOrg(response.body.data);
 }
 
+async function getSandboxes(apiToken: string, project: ResolvedProject): Promise<ISandbox[]> {
+  const response = await apiRequest<{ data: ISandboxResponse[] }>('get', 'sandboxes', {
+    headers: authHeaders(apiToken),
+    searchParams: projectParams(project),
+  });
+
+  if (response.statusCode === 401) {
+    throw sharedMessages.createError('error.authorization');
+  }
+
+  if (response.statusCode < 200 || response.statusCode >= 300) {
+    throw sharedMessages.createError('error.serverError');
+  }
+
+  return response.body.data.map(mapSandbox);
+}
+
+async function getSandboxAuthUrl(apiToken: string, sandboxId: string): Promise<string> {
+  const response = await apiRequest<{ data: { sfdx_auth_url: string } }>('get', `sandboxes/${sandboxId}/auth_url`, {
+    headers: authHeaders(apiToken),
+  });
+
+  if (response.statusCode === 401) {
+    throw sharedMessages.createError('error.authorization');
+  }
+
+  if (response.statusCode === 403) {
+    throw sharedMessages.createError('error.sandboxAuthorizeForbidden');
+  }
+
+  if (response.statusCode === 404) {
+    throw sharedMessages.createError('error.sandboxNotFoundOnHutte');
+  }
+
+  if (response.statusCode < 200 || response.statusCode >= 300) {
+    throw sharedMessages.createError('error.serverError');
+  }
+
+  return response.body.data.sfdx_auth_url;
+}
+
 export default {
   login,
   getMe,
@@ -379,4 +471,6 @@ export default {
   terminateOrg,
   createScratchOrg,
   getScratchOrg,
+  getSandboxes,
+  getSandboxAuthUrl,
 };

--- a/src/api.ts
+++ b/src/api.ts
@@ -466,6 +466,35 @@ async function getSandboxAuthUrl(apiToken: string, sandboxId: string): Promise<s
   return response.body.data.sfdx_auth_url;
 }
 
+async function getSandboxAuthUrlByName(apiToken: string, project: ResolvedProject, name: string): Promise<string> {
+  const response = await apiRequest<{ data: { sfdx_auth_url: string } }>('get', 'sandboxes/auth_url_by_name', {
+    headers: authHeaders(apiToken),
+    searchParams: { ...projectParams(project), name },
+  });
+
+  if (response.statusCode === 401) {
+    throw sharedMessages.createError('error.authorization');
+  }
+
+  if (response.statusCode === 403) {
+    throw sharedMessages.createError('error.sandboxAuthorizeForbidden');
+  }
+
+  if (response.statusCode === 404) {
+    throw sharedMessages.createError('error.sandboxNotFound');
+  }
+
+  if (response.statusCode === 422) {
+    throw sharedMessages.createError('error.sandboxAuthUrlUnavailable');
+  }
+
+  if (response.statusCode < 200 || response.statusCode >= 300) {
+    throw sharedMessages.createError('error.serverError');
+  }
+
+  return response.body.data.sfdx_auth_url;
+}
+
 export default {
   login,
   getMe,
@@ -477,4 +506,5 @@ export default {
   getScratchOrg,
   getSandboxes,
   getSandboxAuthUrl,
+  getSandboxAuthUrlByName,
 };

--- a/src/api.ts
+++ b/src/api.ts
@@ -455,6 +455,10 @@ async function getSandboxAuthUrl(apiToken: string, sandboxId: string): Promise<s
     throw sharedMessages.createError('error.sandboxNotFoundOnHutte');
   }
 
+  if (response.statusCode === 422) {
+    throw sharedMessages.createError('error.sandboxAuthUrlUnavailable');
+  }
+
   if (response.statusCode < 200 || response.statusCode >= 300) {
     throw sharedMessages.createError('error.serverError');
   }

--- a/src/commands/hutte/project/list.ts
+++ b/src/commands/hutte/project/list.ts
@@ -23,15 +23,33 @@ export class List extends SfCommand<IProject[]> {
   public async run(): Promise<IProject[]> {
     const { flags } = await this.parse(List);
     const apiToken = flags['api-token'] ?? (await config.getApiToken());
-    const allProjects = await api.getProjects(apiToken);
-    const result = allProjects.filter((p) => p.projectType === 'scratch_org');
+    const projects = await api.getProjects(apiToken);
+
+    const rows = projects.map((project) => ({
+      id: project.id,
+      name: project.name,
+      repository: project.repository ?? '',
+      type: formatProjectType(project.projectType),
+    }));
+
     this.table({
-      data: result,
-      columns: ['id', 'name', 'repository'],
-      headerOptions: {
-        formatter: 'capitalCase',
-      },
+      data: rows,
+      columns: [
+        { key: 'id', name: 'Id' },
+        { key: 'name', name: 'Name' },
+        { key: 'repository', name: 'Repository' },
+        { key: 'type', name: 'Type' },
+      ],
     });
-    return result;
+
+    return projects;
   }
+}
+
+function formatProjectType(projectType: string): string {
+  return projectType
+    .split('_')
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
 }

--- a/src/commands/hutte/project/set.ts
+++ b/src/commands/hutte/project/set.ts
@@ -51,8 +51,7 @@ export class ProjectSet extends SfCommand<void> {
     }
 
     const apiToken = flags['api-token'] ?? (await config.getApiToken());
-    const allProjects = await api.getProjects(apiToken);
-    const projects = allProjects.filter((p) => p.projectType === 'scratch_org');
+    const projects = await api.getProjects(apiToken);
 
     if (projects.length === 0) {
       throw messages.createError('error.noProjects');

--- a/src/commands/hutte/sandbox/authorize.ts
+++ b/src/commands/hutte/sandbox/authorize.ts
@@ -1,0 +1,85 @@
+import { Flags, SfCommand } from '@salesforce/sf-plugins-core';
+import { Messages } from '@salesforce/core';
+import chalk from 'chalk';
+import Fuse from 'fuse.js';
+import { search as searchPrompt } from '@inquirer/prompts';
+import api, { ISandbox } from '../../../api.js';
+import common from '../../../common.js';
+import config from '../../../config.js';
+import projectResolution from '../../../project-resolution.js';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('hutte', 'hutte.sandbox.authorize');
+const sharedMessages = Messages.loadMessages('hutte', 'shared');
+
+export class Authorize extends SfCommand<void> {
+  public static readonly summary = messages.getMessage('summary');
+
+  public static readonly flags = {
+    'api-token': Flags.string({
+      char: 't',
+      summary: sharedMessages.getMessage('flags.api-token.summary'),
+      env: 'HUTTE_API_TOKEN',
+    }),
+    'sandbox-name': Flags.string({
+      char: 'n',
+      summary: messages.getMessage('flags.sandbox-name.summary'),
+    }),
+    'project-id': Flags.string({
+      char: 'p',
+      summary: sharedMessages.getMessage('flags.project-id.summary'),
+      env: 'HUTTE_PROJECT_ID',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(Authorize);
+    const apiToken = flags['api-token'] ?? (await config.getApiToken());
+    const resolved = await projectResolution.resolveProject(apiToken, flags['project-id']);
+    const sandboxes = await api.getSandboxes(apiToken, resolved);
+    const sandbox = flags['sandbox-name']
+      ? this.findSandbox(sandboxes, flags['sandbox-name'])
+      : await this.chooseSandbox(sandboxes);
+    const sfdxAuthUrl = await api.getSandboxAuthUrl(apiToken, sandbox.id);
+    common.sandboxSfdxLogin(sandbox.name, sfdxAuthUrl);
+  }
+
+  private findSandbox(sandboxes: ISandbox[], nameToFind: string): ISandbox {
+    this.debug(`Finding sandbox with name: ${nameToFind}`);
+    const result = sandboxes.find((sandbox: ISandbox) => sandbox.name === nameToFind);
+    if (!result) {
+      throw messages.createError('error.sandboxNotFound');
+    }
+    return result;
+  }
+
+  private async chooseSandbox(sandboxes: ISandbox[]): Promise<ISandbox> {
+    this.debug(`Choosing from ${sandboxes.length} sandboxes`);
+    if (sandboxes.length === 0) {
+      throw messages.createError('error.noSandboxesToAuthorize');
+    }
+    if (sandboxes.length === 1) {
+      return sandboxes[0];
+    }
+
+    const answer = await searchPrompt({
+      message: messages.getMessage('prompt.chooseSandbox'),
+      source: (term) => {
+        let filtered = sandboxes;
+        if (term) {
+          const fuse = new Fuse(sandboxes, { keys: ['name', 'displayName'], threshold: 0.3 });
+          filtered = fuse.search(term).map((result) => result.item);
+        }
+        return filtered.map((sandbox) => ({
+          value: sandbox.id,
+          name: `${sandbox.name} ${chalk.gray(`- ${sandbox.projectName}`)}`,
+        }));
+      },
+    });
+    const selected = sandboxes.find((sandbox) => sandbox.id === answer);
+    if (!selected) {
+      throw messages.createError('error.noSandboxSelected');
+    }
+    return selected;
+  }
+}

--- a/src/commands/hutte/sandbox/authorize.ts
+++ b/src/commands/hutte/sandbox/authorize.ts
@@ -50,7 +50,17 @@ export class Authorize extends SfCommand<void> {
       sfdxAuthUrl = await api.getSandboxAuthUrl(apiToken, sandbox.id);
     }
 
+    this.spinner.start(messages.getMessage('spinner.authorizing', [sandboxName]));
     common.sandboxSfdxLogin(sandboxName, sfdxAuthUrl);
+    this.spinner.stop();
+
+    const alias = `hutte-${sandboxName}`;
+    const username = resolveDefaultUsername();
+    this.logSuccess(
+      username
+        ? messages.getMessage('success.authorizedAs', [sandboxName, username, alias])
+        : messages.getMessage('success.authorized', [sandboxName, alias])
+    );
   }
 
   private async chooseSandbox(sandboxes: ISandbox[]): Promise<ISandbox> {
@@ -59,6 +69,7 @@ export class Authorize extends SfCommand<void> {
       throw messages.createError('error.noSandboxesToAuthorize');
     }
     if (sandboxes.length === 1) {
+      this.info(messages.getMessage('info.autoSelected', [sandboxes[0].name]));
       return sandboxes[0];
     }
 
@@ -81,5 +92,14 @@ export class Authorize extends SfCommand<void> {
       throw messages.createError('error.noSandboxSelected');
     }
     return selected;
+  }
+}
+
+function resolveDefaultUsername(): string | undefined {
+  try {
+    return common.getDefaultOrgInfo().username;
+  } catch {
+    // Best-effort: a display hiccup must not turn a successful login into a failure.
+    return undefined;
   }
 }

--- a/src/commands/hutte/sandbox/authorize.ts
+++ b/src/commands/hutte/sandbox/authorize.ts
@@ -36,21 +36,21 @@ export class Authorize extends SfCommand<void> {
     const { flags } = await this.parse(Authorize);
     const apiToken = flags['api-token'] ?? (await config.getApiToken());
     const resolved = await projectResolution.resolveProject(apiToken, flags['project-id']);
-    const sandboxes = await api.getSandboxes(apiToken, resolved);
-    const sandbox = flags['sandbox-name']
-      ? this.findSandbox(sandboxes, flags['sandbox-name'])
-      : await this.chooseSandbox(sandboxes);
-    const sfdxAuthUrl = await api.getSandboxAuthUrl(apiToken, sandbox.id);
-    common.sandboxSfdxLogin(sandbox.name, sfdxAuthUrl);
-  }
 
-  private findSandbox(sandboxes: ISandbox[], nameToFind: string): ISandbox {
-    this.debug(`Finding sandbox with name: ${nameToFind}`);
-    const result = sandboxes.find((sandbox: ISandbox) => sandbox.name === nameToFind);
-    if (!result) {
-      throw messages.createError('error.sandboxNotFound');
+    let sandboxName: string;
+    let sfdxAuthUrl: string;
+
+    if (flags['sandbox-name']) {
+      sandboxName = flags['sandbox-name'];
+      sfdxAuthUrl = await api.getSandboxAuthUrlByName(apiToken, resolved, sandboxName);
+    } else {
+      const sandboxes = await api.getSandboxes(apiToken, resolved);
+      const sandbox = await this.chooseSandbox(sandboxes);
+      sandboxName = sandbox.name;
+      sfdxAuthUrl = await api.getSandboxAuthUrl(apiToken, sandbox.id);
     }
-    return result;
+
+    common.sandboxSfdxLogin(sandboxName, sfdxAuthUrl);
   }
 
   private async chooseSandbox(sandboxes: ISandbox[]): Promise<ISandbox> {

--- a/src/commands/hutte/sandbox/list.ts
+++ b/src/commands/hutte/sandbox/list.ts
@@ -1,0 +1,62 @@
+import { Flags, SfCommand } from '@salesforce/sf-plugins-core';
+import { Messages } from '@salesforce/core';
+import api, { ISandbox } from '../../../api.js';
+import config from '../../../config.js';
+import projectResolution from '../../../project-resolution.js';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('hutte', 'hutte.sandbox.list');
+const sharedMessages = Messages.loadMessages('hutte', 'shared');
+
+export class List extends SfCommand<ISandbox[]> {
+  public static readonly summary = messages.getMessage('summary');
+
+  public static readonly flags = {
+    'api-token': Flags.string({
+      char: 't',
+      summary: sharedMessages.getMessage('flags.api-token.summary'),
+      env: 'HUTTE_API_TOKEN',
+    }),
+    'project-id': Flags.string({
+      char: 'p',
+      summary: sharedMessages.getMessage('flags.project-id.summary'),
+      env: 'HUTTE_PROJECT_ID',
+    }),
+  };
+
+  public async run(): Promise<ISandbox[]> {
+    const { flags } = await this.parse(List);
+    const apiToken = flags['api-token'] ?? (await config.getApiToken());
+    const resolved = await projectResolution.resolveProject(apiToken, flags['project-id']);
+    const result = await api.getSandboxes(apiToken, resolved);
+
+    const rows = result.map((sandbox) => ({
+      name: sandbox.name,
+      displayName: sandbox.displayName ?? '',
+      projectName: sandbox.projectName,
+      licenseType: sandbox.licenseType ?? '',
+      status: sandbox.salesforceStatus,
+      lastRefreshedAt: sandbox.lastRefreshedAt ?? '',
+      createSandboxFrom: sandbox.createSandboxFrom ?? '',
+      salesforceUser: sandbox.salesforceUser?.name ?? '',
+      pool: sandbox.pool ? 'yes' : 'no',
+    }));
+
+    this.table({
+      data: rows,
+      columns: [
+        { key: 'name', name: 'Name' },
+        { key: 'displayName', name: 'Display Name' },
+        { key: 'projectName', name: 'Project' },
+        { key: 'licenseType', name: 'License' },
+        { key: 'status', name: 'Status' },
+        { key: 'lastRefreshedAt', name: 'Last Refreshed' },
+        { key: 'createSandboxFrom', name: 'Created From' },
+        { key: 'salesforceUser', name: 'Salesforce User' },
+        { key: 'pool', name: 'Pool' },
+      ],
+    });
+
+    return result;
+  }
+}

--- a/src/common.ts
+++ b/src/common.ts
@@ -46,7 +46,8 @@ function sandboxSfdxLogin(sandboxName: string, sfdxAuthUrl: string): void {
     }
   );
   if (response.status !== 0) {
-    throw messages.createError('error.loginFailed');
+    const details = response.stderr?.toString().trim();
+    throw messages.createError('error.sandboxLoginFailed', [details || 'unknown error']);
   }
 }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -37,6 +37,19 @@ function sfdxLogin(org: IScratchOrg): IScratchOrg {
   return org;
 }
 
+function sandboxSfdxLogin(sandboxName: string, sfdxAuthUrl: string): void {
+  const response = crossSpawn.sync(
+    'sf',
+    ['org', 'login', 'sfdx-url', '--alias', `hutte-${sandboxName}`, '--set-default', '--sfdx-url-stdin'],
+    {
+      input: sfdxAuthUrl,
+    }
+  );
+  if (response.status !== 0) {
+    throw messages.createError('error.loginFailed');
+  }
+}
+
 function logoutFromDefault(): void {
   const result = crossSpawn.sync('sf', ['org', 'logout', '--no-prompt']);
   if (result.status === 0) {
@@ -131,6 +144,7 @@ async function pollForOrgStatus(fetchOrg: () => Promise<IScratchOrg>, options: P
 
 export default {
   sfdxLogin,
+  sandboxSfdxLogin,
   logoutFromDefault,
   getDefaultOrgInfo,
   projectRepoFromOrigin,

--- a/test/commands/project/list.test.ts
+++ b/test/commands/project/list.test.ts
@@ -44,7 +44,7 @@ describe('hutte:project:list', () => {
     expect(apiStubs.getProjects.calledWith('custom-token')).to.equal(true);
   });
 
-  it('filters out sandbox projects', async () => {
+  it('includes sandbox projects', async () => {
     const mixedProjects = [
       createMockProject({ id: 'scratch1', name: 'Scratch Project', projectType: 'scratch_org' }),
       createMockProject({ id: 'sandbox1', name: 'Sandbox Project', projectType: 'sandbox' }),
@@ -52,8 +52,8 @@ describe('hutte:project:list', () => {
     apiStubs.getProjects.resolves(mixedProjects);
 
     const result = await List.run([]);
-    expect(result).to.have.lengthOf(1);
-    expect(result[0].id).to.equal('scratch1');
+    expect(result).to.have.lengthOf(2);
+    expect(result.map((p) => p.id)).to.deep.equal(['scratch1', 'sandbox1']);
   });
 
   it('fails when authorization fails', async () => {

--- a/test/commands/project/set.test.ts
+++ b/test/commands/project/set.test.ts
@@ -111,28 +111,26 @@ describe('hutte:project:set', () => {
     }
   });
 
-  it('filters out sandbox projects', async () => {
+  it('sets a sandbox project as default from a mixed list', async () => {
     const mixedProjects = [
       createMockProject({ id: 'scratch1', name: 'Scratch Project', projectType: 'scratch_org' }),
       createMockProject({ id: 'sandbox1', name: 'Sandbox Project', projectType: 'sandbox' }),
     ];
     apiStubs.getProjects.resolves(mixedProjects);
 
-    await ProjectSet.run(['--project-id', 'scratch1']);
+    await ProjectSet.run(['--project-id', 'sandbox1']);
 
     expect(storeStub.calledOnce).to.equal(true);
-    expect(storeStub.firstCall.args[0]).to.deep.include({ id: 'scratch1' });
+    expect(storeStub.firstCall.args[0]).to.deep.include({ id: 'sandbox1', projectType: 'sandbox' });
   });
 
-  it('fails when only sandbox projects exist', async () => {
+  it('sets a sandbox project as default when only sandbox projects exist', async () => {
     const sandboxOnly = [createMockProject({ id: 'sandbox1', name: 'Sandbox Project', projectType: 'sandbox' })];
     apiStubs.getProjects.resolves(sandboxOnly);
 
-    try {
-      await ProjectSet.run(['--project-id', 'sandbox1']);
-      expect.fail('should throw an error');
-    } catch (e) {
-      expect(e).to.be.instanceOf(SfError);
-    }
+    await ProjectSet.run(['--project-id', 'sandbox1']);
+
+    expect(storeStub.calledOnce).to.equal(true);
+    expect(storeStub.firstCall.args[0]).to.deep.include({ id: 'sandbox1', projectType: 'sandbox' });
   });
 });

--- a/test/commands/sandbox/authorize.test.ts
+++ b/test/commands/sandbox/authorize.test.ts
@@ -31,6 +31,7 @@ describe('hutte:sandbox:authorize', () => {
 
     apiStubs.getSandboxes.resolves([mockSandbox]);
     apiStubs.getSandboxAuthUrl.resolves('force://proxy@app.hutte.io');
+    apiStubs.getSandboxAuthUrlByName.resolves('force://proxy@app.hutte.io');
   });
 
   afterEach(() => {
@@ -43,23 +44,28 @@ describe('hutte:sandbox:authorize', () => {
     expect(commonStubs.sandboxSfdxLogin.calledOnceWith(mockSandbox.name, 'force://proxy@app.hutte.io')).to.equal(true);
   });
 
-  it('authorizes a sandbox by name', async () => {
+  it('authorizes a sandbox by name via the by-name endpoint', async () => {
     await Authorize.run(['--sandbox-name', 'uat01']);
-    expect(commonStubs.sandboxSfdxLogin.calledOnce).to.equal(true);
+    expect(apiStubs.getSandboxes.called).to.equal(false);
+    expect(apiStubs.getSandboxAuthUrlByName.calledOnce).to.equal(true);
+    expect(apiStubs.getSandboxAuthUrlByName.firstCall.args[2]).to.equal('uat01');
+    expect(commonStubs.sandboxSfdxLogin.calledOnceWith('uat01', 'force://proxy@app.hutte.io')).to.equal(true);
   });
 
   it('fails when the sandbox name does not exist', async () => {
+    apiStubs.getSandboxAuthUrlByName.rejects(new SfError('Could not find a sandbox with that name in this project.'));
+
     try {
       await Authorize.run(['--sandbox-name', 'nonexistent']);
       expect.fail('should throw an error');
     } catch (e) {
       expect(e).to.be.instanceOf(SfError);
-      expect((e as SfError).message).to.match(/not any sandbox to authorize/);
+      expect((e as SfError).message).to.match(/Could not find a sandbox with that name/);
     }
   });
 
   it('surfaces the forbidden error for non-admins', async () => {
-    apiStubs.getSandboxAuthUrl.rejects(new SfError('Only project admins can authorize sandboxes.'));
+    apiStubs.getSandboxAuthUrlByName.rejects(new SfError('Only project admins can authorize sandboxes.'));
 
     try {
       await Authorize.run(['--sandbox-name', 'uat01']);

--- a/test/commands/sandbox/authorize.test.ts
+++ b/test/commands/sandbox/authorize.test.ts
@@ -20,10 +20,11 @@ describe('hutte:sandbox:authorize', () => {
   const mockSandbox = createMockSandbox();
   let apiStubs: ApiStubs;
   let commonStubs: CommonStubs;
+  let uxStubs: ReturnType<typeof stubSfCommandUx>;
 
   beforeEach(async () => {
     await testContext.stubAuths(testOrg);
-    stubSfCommandUx(testContext.SANDBOX);
+    uxStubs = stubSfCommandUx(testContext.SANDBOX);
     apiStubs = stubApiMethods(testContext.SANDBOX);
     stubConfigMethods(testContext.SANDBOX);
     commonStubs = stubCommonMethods(testContext.SANDBOX);
@@ -112,5 +113,31 @@ describe('hutte:sandbox:authorize', () => {
       (args: unknown[]) => args[0] === 'sf' && Array.isArray(args[1]) && (args[1] as string[]).includes('sfdx-url')
     );
     expect(sfLoginCalls).to.have.lengthOf(1);
+  });
+
+  it('reports success with the logged-in username', async () => {
+    commonStubs.getDefaultOrgInfo.returns({ id: '00D000000000000', username: 'jane@acme.com.uat01' });
+
+    await Authorize.run([]);
+
+    expect(uxStubs.logSuccess.calledOnce).to.equal(true);
+    expect(uxStubs.logSuccess.firstCall.args[0]).to.match(/Authorized sandbox uat01 as/);
+    expect(uxStubs.logSuccess.firstCall.args[0]).to.match(/jane@acme\.com\.uat01/);
+  });
+
+  it('reports success without a username when org display fails', async () => {
+    commonStubs.getDefaultOrgInfo.throws(new Error('no default org'));
+
+    await Authorize.run([]);
+
+    expect(uxStubs.logSuccess.calledOnce).to.equal(true);
+    expect(uxStubs.logSuccess.firstCall.args[0]).to.match(/Authorized sandbox uat01/);
+  });
+
+  it('announces the auto-selected sandbox when only one exists', async () => {
+    await Authorize.run([]);
+
+    expect(uxStubs.info.calledOnce).to.equal(true);
+    expect(uxStubs.info.firstCall.args[0]).to.match(/uat01/);
   });
 });

--- a/test/commands/sandbox/authorize.test.ts
+++ b/test/commands/sandbox/authorize.test.ts
@@ -1,0 +1,88 @@
+import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
+import { stubSfCommandUx } from '@salesforce/sf-plugins-core';
+import { expect } from 'chai';
+import { SfError } from '@salesforce/core';
+import { Authorize } from '../../../src/commands/hutte/sandbox/authorize.js';
+import {
+  createMockSandbox,
+  stubApiMethods,
+  stubConfigMethods,
+  stubCommonMethods,
+  stubCrossSpawnSync,
+  stubProjectResolution,
+  type ApiStubs,
+  type CommonStubs,
+} from '../../helpers.js';
+
+describe('hutte:sandbox:authorize', () => {
+  const testContext = new TestContext();
+  const testOrg = new MockTestOrgData();
+  const mockSandbox = createMockSandbox();
+  let apiStubs: ApiStubs;
+  let commonStubs: CommonStubs;
+
+  beforeEach(async () => {
+    await testContext.stubAuths(testOrg);
+    stubSfCommandUx(testContext.SANDBOX);
+    apiStubs = stubApiMethods(testContext.SANDBOX);
+    stubConfigMethods(testContext.SANDBOX);
+    commonStubs = stubCommonMethods(testContext.SANDBOX);
+    stubProjectResolution(testContext.SANDBOX);
+
+    apiStubs.getSandboxes.resolves([mockSandbox]);
+    apiStubs.getSandboxAuthUrl.resolves('force://proxy@app.hutte.io');
+  });
+
+  afterEach(() => {
+    testContext.restore();
+  });
+
+  it('authorizes the only sandbox (login only)', async () => {
+    await Authorize.run([]);
+    expect(apiStubs.getSandboxAuthUrl.calledOnceWith('t123', mockSandbox.id)).to.equal(true);
+    expect(commonStubs.sandboxSfdxLogin.calledOnceWith(mockSandbox.name, 'force://proxy@app.hutte.io')).to.equal(true);
+  });
+
+  it('authorizes a sandbox by name', async () => {
+    await Authorize.run(['--sandbox-name', 'uat01']);
+    expect(commonStubs.sandboxSfdxLogin.calledOnce).to.equal(true);
+  });
+
+  it('fails when the sandbox name does not exist', async () => {
+    try {
+      await Authorize.run(['--sandbox-name', 'nonexistent']);
+      expect.fail('should throw an error');
+    } catch (e) {
+      expect(e).to.be.instanceOf(SfError);
+      expect((e as SfError).message).to.match(/not any sandbox to authorize/);
+    }
+  });
+
+  it('surfaces the forbidden error for non-admins', async () => {
+    apiStubs.getSandboxAuthUrl.rejects(new SfError('Only project admins can authorize sandboxes.'));
+
+    try {
+      await Authorize.run(['--sandbox-name', 'uat01']);
+      expect.fail('should throw an error');
+    } catch (e) {
+      expect(e).to.be.instanceOf(SfError);
+      expect((e as SfError).message).to.match(/Only project admins can authorize sandboxes/);
+    }
+  });
+
+  it('runs no git commands, only the sf login (login only)', async () => {
+    // Restore the helper stub so the REAL sandboxSfdxLogin runs (with crossSpawn stubbed).
+    commonStubs.sandboxSfdxLogin.restore();
+    const crossSpawnStubs = stubCrossSpawnSync(testContext.SANDBOX);
+
+    await Authorize.run([]);
+
+    const gitCalls = crossSpawnStubs.sync.args.filter((args: unknown[]) => args[0] === 'git');
+    expect(gitCalls).to.have.lengthOf(0);
+
+    const sfLoginCalls = crossSpawnStubs.sync.args.filter(
+      (args: unknown[]) => args[0] === 'sf' && Array.isArray(args[1]) && (args[1] as string[]).includes('sfdx-url')
+    );
+    expect(sfLoginCalls).to.have.lengthOf(1);
+  });
+});

--- a/test/commands/sandbox/authorize.test.ts
+++ b/test/commands/sandbox/authorize.test.ts
@@ -76,6 +76,28 @@ describe('hutte:sandbox:authorize', () => {
     }
   });
 
+  it('surfaces the underlying sf error when the login fails', async () => {
+    // Run the real sandboxSfdxLogin with cross-spawn stubbed to fail.
+    commonStubs.sandboxSfdxLogin.restore();
+    const crossSpawnStubs = stubCrossSpawnSync(testContext.SANDBOX);
+    crossSpawnStubs.sync.returns({
+      status: 1,
+      signal: null,
+      pid: 0,
+      output: [],
+      stdout: Buffer.from(''),
+      stderr: Buffer.from('Invalid SFDX auth URL'),
+    });
+
+    try {
+      await Authorize.run([]);
+      expect.fail('should throw an error');
+    } catch (e) {
+      expect(e).to.be.instanceOf(SfError);
+      expect((e as SfError).message).to.match(/Invalid SFDX auth URL/);
+    }
+  });
+
   it('runs no git commands, only the sf login (login only)', async () => {
     // Restore the helper stub so the REAL sandboxSfdxLogin runs (with crossSpawn stubbed).
     commonStubs.sandboxSfdxLogin.restore();

--- a/test/commands/sandbox/list.test.ts
+++ b/test/commands/sandbox/list.test.ts
@@ -1,0 +1,66 @@
+import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
+import { stubSfCommandUx } from '@salesforce/sf-plugins-core';
+import { expect } from 'chai';
+import { SfError } from '@salesforce/core';
+import { List } from '../../../src/commands/hutte/sandbox/list.js';
+import {
+  createMockSandboxList,
+  stubApiMethods,
+  stubConfigMethods,
+  stubCommonMethods,
+  stubProjectResolution,
+  type ApiStubs,
+} from '../../helpers.js';
+
+describe('hutte:sandbox:list', () => {
+  const testContext = new TestContext();
+  const testOrg = new MockTestOrgData();
+  const mockSandboxes = createMockSandboxList(3);
+  let apiStubs: ApiStubs;
+
+  beforeEach(async () => {
+    await testContext.stubAuths(testOrg);
+    stubSfCommandUx(testContext.SANDBOX);
+    stubCommonMethods(testContext.SANDBOX, '');
+    stubConfigMethods(testContext.SANDBOX);
+    stubProjectResolution(testContext.SANDBOX);
+    apiStubs = stubApiMethods(testContext.SANDBOX);
+    apiStubs.getSandboxes.resolves(mockSandboxes);
+  });
+
+  afterEach(() => {
+    testContext.restore();
+  });
+
+  it('lists the project sandboxes', async () => {
+    const result = await List.run([]);
+    expect(result).to.have.lengthOf(3);
+    expect(result[0].name).to.equal('uat01');
+    expect(result[0].salesforceStatus).to.equal('completed');
+    expect(result[0].licenseType).to.equal('DEVELOPER');
+  });
+
+  it('fails when authorization fails', async () => {
+    apiStubs.getSandboxes.rejects(new SfError('There is an error with authorization.'));
+
+    try {
+      await List.run([]);
+      expect.fail('should throw an error');
+    } catch (e) {
+      expect(e).to.be.instanceOf(SfError);
+      expect((e as SfError).message).to.match(/There is an error with authorization/);
+    }
+  });
+
+  it('fails when server returns an error', async () => {
+    apiStubs.getSandboxes.rejects(new SfError('Request to Hutte failed.'));
+
+    try {
+      await List.run([]);
+      expect.fail('should throw an error');
+    } catch (e) {
+      expect(e).to.be.instanceOf(SfError);
+      expect((e as SfError).message).to.match(/Request to Hutte failed/);
+    }
+  });
+});

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -133,6 +133,7 @@ export type ApiStubs = {
   getScratchOrg: SinonStub;
   getSandboxes: SinonStub;
   getSandboxAuthUrl: SinonStub;
+  getSandboxAuthUrlByName: SinonStub;
 };
 
 /**
@@ -150,6 +151,7 @@ export function stubApiMethods(sandbox: SinonSandbox): ApiStubs {
     getScratchOrg: sandbox.stub(api, 'getScratchOrg'),
     getSandboxes: sandbox.stub(api, 'getSandboxes'),
     getSandboxAuthUrl: sandbox.stub(api, 'getSandboxAuthUrl'),
+    getSandboxAuthUrlByName: sandbox.stub(api, 'getSandboxAuthUrlByName'),
   };
 }
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,6 +1,6 @@
 import { type SinonSandbox, type SinonStub } from 'sinon';
 import crossSpawn from 'cross-spawn';
-import api, { type IScratchOrg, type IProject } from '../src/api.js';
+import api, { type IScratchOrg, type IProject, type ISandbox } from '../src/api.js';
 import common from '../src/common.js';
 import config from '../src/config.js';
 import keychain from '../src/keychain.js';
@@ -85,6 +85,43 @@ export function createMockProjectList(count: number): IProject[] {
   );
 }
 
+/**
+ * Default mock sandbox data for testing.
+ */
+const DEFAULT_SANDBOX: ISandbox = {
+  id: 'mockSandboxId',
+  name: 'uat01',
+  displayName: 'UAT 01',
+  projectId: 'mockProjectId',
+  projectName: 'Mock Project',
+  pool: false,
+  licenseType: 'DEVELOPER',
+  createSandboxFrom: null,
+  salesforceUser: { id: '005XX', name: 'Test SF User' },
+  salesforceStatus: 'completed',
+  lastRefreshedAt: '2026-05-01T10:00:00.000Z',
+};
+
+/**
+ * Creates a mock ISandbox object with optional overrides.
+ */
+export function createMockSandbox(overrides?: Partial<ISandbox>): ISandbox {
+  return { ...DEFAULT_SANDBOX, ...overrides };
+}
+
+/**
+ * Creates multiple mock sandboxes with incrementing values.
+ */
+export function createMockSandboxList(count: number): ISandbox[] {
+  return Array.from({ length: count }, (_, i) =>
+    createMockSandbox({
+      id: `mockSandboxId${i + 1}`,
+      name: `uat0${i + 1}`,
+      displayName: `UAT 0${i + 1}`,
+    })
+  );
+}
+
 export type ApiStubs = {
   login: SinonStub;
   getMe: SinonStub;
@@ -94,6 +131,8 @@ export type ApiStubs = {
   terminateOrg: SinonStub;
   createScratchOrg: SinonStub;
   getScratchOrg: SinonStub;
+  getSandboxes: SinonStub;
+  getSandboxAuthUrl: SinonStub;
 };
 
 /**
@@ -109,6 +148,8 @@ export function stubApiMethods(sandbox: SinonSandbox): ApiStubs {
     terminateOrg: sandbox.stub(api, 'terminateOrg'),
     createScratchOrg: sandbox.stub(api, 'createScratchOrg'),
     getScratchOrg: sandbox.stub(api, 'getScratchOrg'),
+    getSandboxes: sandbox.stub(api, 'getSandboxes'),
+    getSandboxAuthUrl: sandbox.stub(api, 'getSandboxAuthUrl'),
   };
 }
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -173,6 +173,7 @@ export function stubConfigMethods(sandbox: SinonSandbox, apiToken = 't123'): Con
 export type CommonStubs = {
   projectRepoFromOrigin: SinonStub;
   sfdxLogin: SinonStub;
+  sandboxSfdxLogin: SinonStub;
   getDefaultOrgInfo: SinonStub;
   logoutFromDefault: SinonStub;
   pollForOrgStatus: SinonStub;
@@ -188,6 +189,7 @@ export function stubCommonMethods(
   return {
     projectRepoFromOrigin: sandbox.stub(common, 'projectRepoFromOrigin').returns(repoUrl),
     sfdxLogin: sandbox.stub(common, 'sfdxLogin'),
+    sandboxSfdxLogin: sandbox.stub(common, 'sandboxSfdxLogin'),
     getDefaultOrgInfo: sandbox.stub(common, 'getDefaultOrgInfo'),
     logoutFromDefault: sandbox.stub(common, 'logoutFromDefault'),
     pollForOrgStatus: sandbox.stub(common, 'pollForOrgStatus'),


### PR DESCRIPTION
## Summary
- **`sf hutte sandbox list`** — lists the project's sandboxes with live Salesforce data: name, display name, project, license, status, last refreshed, source sandbox, Salesforce user, and a `pool` flag. Available to any project member.
- **`sf hutte sandbox authorize`** — logs into a sandbox via `sf org login sfdx-url` with alias `hutte-<name>` (login only — no git checkout, no source pull). Supports `--sandbox-name` (resolved on the backend) or an interactive fuzzy picker. **Project admins only** — enforced by the backend; a clear message is surfaced on 403.
